### PR TITLE
Link OrganizationMembers to Organization with an owner reference

### DIFF
--- a/apiserver/organization/mock/namespace.go
+++ b/apiserver/organization/mock/namespace.go
@@ -39,11 +39,12 @@ func (m *MocknamespaceProvider) EXPECT() *MocknamespaceProviderMockRecorder {
 }
 
 // CreateNamespace mocks base method.
-func (m *MocknamespaceProvider) CreateNamespace(ctx context.Context, ns *v1.Namespace, options *v10.CreateOptions) error {
+func (m *MocknamespaceProvider) CreateNamespace(ctx context.Context, ns *v1.Namespace, options *v10.CreateOptions) (*v1.Namespace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNamespace", ctx, ns, options)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*v1.Namespace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateNamespace indicates an expected call of CreateNamespace.

--- a/apiserver/organization/namespace.go
+++ b/apiserver/organization/namespace.go
@@ -16,7 +16,7 @@ import (
 type namespaceProvider interface {
 	GetNamespace(ctx context.Context, name string, options *metav1.GetOptions) (*corev1.Namespace, error)
 	DeleteNamespace(ctx context.Context, name string, options *metav1.DeleteOptions) (*corev1.Namespace, error)
-	CreateNamespace(ctx context.Context, ns *corev1.Namespace, options *metav1.CreateOptions) error
+	CreateNamespace(ctx context.Context, ns *corev1.Namespace, options *metav1.CreateOptions) (*corev1.Namespace, error)
 	UpdateNamespace(ctx context.Context, ns *corev1.Namespace, options *metav1.UpdateOptions) error
 	ListNamespaces(ctx context.Context, options *metainternalversion.ListOptions) (*corev1.NamespaceList, error)
 	WatchNamespaces(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error)
@@ -41,10 +41,11 @@ func (p *kubeNamespaceProvider) DeleteNamespace(ctx context.Context, name string
 	return &ns, err
 }
 
-func (p *kubeNamespaceProvider) CreateNamespace(ctx context.Context, ns *corev1.Namespace, options *metav1.CreateOptions) error {
-	return p.Client.Create(ctx, ns, &client.CreateOptions{
+func (p *kubeNamespaceProvider) CreateNamespace(ctx context.Context, ns *corev1.Namespace, options *metav1.CreateOptions) (*corev1.Namespace, error) {
+	err := p.Client.Create(ctx, ns, &client.CreateOptions{
 		Raw: options,
 	})
+	return ns, err
 }
 
 func (p *kubeNamespaceProvider) UpdateNamespace(ctx context.Context, ns *corev1.Namespace, options *metav1.UpdateOptions) error {


### PR DESCRIPTION
## Summary

By linking them with an ownerRef, a controller can easily reconcile on both without jumping through some hoops.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
