### PR TITLE
Remove user id from reference

### DIFF
--- a/apis/v1/organizationmembers_type.go
+++ b/apis/v1/organizationmembers_type.go
@@ -28,8 +28,7 @@ type OrganizationMembersStatus struct {
 
 // UserRef points to a user
 type UserRef struct {
-	ID       string `json:"id,omitempty"`
-	Username string `json:"username,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/v1/user_types.go
+++ b/apis/v1/user_types.go
@@ -30,6 +30,7 @@ type UserPreferences struct {
 // UserStatus contains the acutal state of the user
 type UserStatus struct {
 	DefaultOrganizationRef string `json:"defaultOrganization,omitempty"`
+	ID                     string `json:"id,omitempty"`
 	DisplayName            string `json:"displayName,omitempty"`
 	Username               string `json:"username,omitempty"`
 	Email                  string `json:"email,omitempty"`

--- a/apiserver/organization/create.go
+++ b/apiserver/organization/create.go
@@ -70,7 +70,7 @@ func newOrganizationMembers(ctx context.Context, organization *orgv1.Organizatio
 	user, ok := request.UserFrom(ctx)
 	if ok {
 		userRefs = append(userRefs, controlv1.UserRef{
-			ID: strings.TrimPrefix(user.GetName(), usernamePrefix),
+			Name: strings.TrimPrefix(user.GetName(), usernamePrefix),
 		})
 	}
 

--- a/apiserver/organization/create_test.go
+++ b/apiserver/organization/create_test.go
@@ -216,7 +216,7 @@ func (m memberMatcher) Matches(x interface{}) bool {
 	if !ok {
 		return ok
 	}
-	return len(mem.Spec.UserRefs) > 0 && mem.Spec.UserRefs[0].ID == m.user &&
+	return len(mem.Spec.UserRefs) > 0 && mem.Spec.UserRefs[0].Name == m.user &&
 		len(mem.OwnerReferences) > 0 && mem.OwnerReferences[0].Name == m.owner
 }
 

--- a/config/crd/apiextensions.k8s.io/v1/base/appuio.io_organizationmembers.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/appuio.io_organizationmembers.yaml
@@ -41,9 +41,7 @@ spec:
                 items:
                   description: UserRef points to a user
                   properties:
-                    id:
-                      type: string
-                    username:
+                    name:
                       type: string
                   type: object
                 type: array
@@ -56,9 +54,7 @@ spec:
                 items:
                   description: UserRef points to a user
                   properties:
-                    id:
-                      type: string
-                    username:
+                    name:
                       type: string
                   type: object
                 type: array

--- a/config/crd/apiextensions.k8s.io/v1/base/appuio.io_users.yaml
+++ b/config/crd/apiextensions.k8s.io/v1/base/appuio.io_users.yaml
@@ -52,6 +52,8 @@ spec:
                 type: string
               email:
                 type: string
+              id:
+                type: string
               username:
                 type: string
             type: object


### PR DESCRIPTION
We decided to transition to only using the username and not the ID. It's the adapters job to resolve the username if necessary

Change documented in: https://github.com/appuio/appuio-io-docs/pull/107


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
