### PR TITLE
Only add APPUiO user as members on Organization creation

### DIFF
--- a/apiserver/organization/create.go
+++ b/apiserver/organization/create.go
@@ -10,7 +10,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
 
@@ -67,7 +66,7 @@ func (s *organizationStorage) create(ctx context.Context, org *orgv1.Organizatio
 
 func newOrganizationMembers(ctx context.Context, organization *orgv1.Organization, usernamePrefix string) *controlv1.OrganizationMembers {
 	userRefs := []controlv1.UserRef{}
-	user, ok := request.UserFrom(ctx)
+	user, ok := userFrom(ctx, usernamePrefix)
 	if ok {
 		userRefs = append(userRefs, controlv1.UserRef{
 			Name: strings.TrimPrefix(user.GetName(), usernamePrefix),

--- a/apiserver/organization/create_test.go
+++ b/apiserver/organization/create_test.go
@@ -26,6 +26,7 @@ import (
 func TestOrganizationStorage_Create(t *testing.T) {
 	tests := map[string]struct {
 		userID         string
+		userGroups     []string
 		organizationIn *orgv1.Organization
 
 		namespaceErr error
@@ -34,8 +35,9 @@ func TestOrganizationStorage_Create(t *testing.T) {
 
 		memberName string
 
-		organizationOut *orgv1.Organization
-		err             error
+		skipRoleBindings bool
+		organizationOut  *orgv1.Organization
+		err              error
 	}{
 		"GivenCreateOrg_ThenSuccess": {
 			userID:         "appuio#smith",
@@ -46,14 +48,26 @@ func TestOrganizationStorage_Create(t *testing.T) {
 			memberName:      "smith",
 			organizationOut: fooOrg,
 		},
-		"GivenCreateOrgFromNonAPPUiOUser_ThenSuccess": {
+		"GivenCreateOrgFromNonAPPUiOUser_ThenSuccessButNoSA": {
 			userID:         "cluster-admin",
 			organizationIn: fooOrg,
 			authDecision: authResponse{
 				decision: authorizer.DecisionAllow,
 			},
-			memberName:      "",
-			organizationOut: fooOrg,
+			memberName:       "",
+			organizationOut:  fooOrg,
+			skipRoleBindings: true,
+		},
+		"GivenCreateOrgFromSA_ThenSuccessButNoSA": {
+			userID:         "appuio#serviceacount",
+			userGroups:     []string{"system:serviceaccounts"},
+			organizationIn: fooOrg,
+			authDecision: authResponse{
+				decision: authorizer.DecisionAllow,
+			},
+			memberName:       "",
+			organizationOut:  fooOrg,
+			skipRoleBindings: true,
 		},
 		"GivenNsExists_ThenFail": {
 			organizationIn: fooOrg,
@@ -67,13 +81,15 @@ func TestOrganizationStorage_Create(t *testing.T) {
 				Group:    orgv1.GroupVersion.Group,
 				Resource: "organizations",
 			}, "foo"),
+			skipRoleBindings: true,
 		},
 		"GivenAuthFails_ThenFail": {
 			organizationIn: fooOrg,
 			authDecision: authResponse{
 				err: errors.New("failed"),
 			},
-			err: errors.New("failed"),
+			err:              errors.New("failed"),
+			skipRoleBindings: true,
 		},
 		"GivenForbidden_ThenForbidden": {
 			organizationIn: fooOrg,
@@ -85,6 +101,7 @@ func TestOrganizationStorage_Create(t *testing.T) {
 				Group:    orgv1.GroupVersion.Group,
 				Resource: "organizations",
 			}, fooOrg.Name, errors.New("confidential")),
+			skipRoleBindings: true,
 		},
 	}
 
@@ -110,10 +127,12 @@ func TestOrganizationStorage_Create(t *testing.T) {
 				CreateNamespace(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nsOut, tc.namespaceErr).
 				AnyTimes()
-			mrb.EXPECT().
-				CreateRoleBindings(gomock.Any(), gomock.Any()).
-				Return(nil).
-				AnyTimes()
+			if !tc.skipRoleBindings {
+				mrb.EXPECT().
+					CreateRoleBindings(gomock.Any(), tc.organizationIn.Name, "appuio#"+tc.memberName).
+					Return(nil).
+					Times(1)
+			}
 			mmemb.EXPECT().
 				CreateMembers(gomock.Any(), containsMemberAndOwner(tc.organizationIn.Name, tc.memberName)).
 				Return(nil).
@@ -129,7 +148,8 @@ func TestOrganizationStorage_Create(t *testing.T) {
 					Resource: "organizations",
 					Name:     tc.organizationIn.Name,
 				}), &user.DefaultInfo{
-				Name: tc.userID,
+				Name:   tc.userID,
+				Groups: tc.userGroups,
 			}),
 				tc.organizationIn, nopValidate, nil)
 
@@ -165,6 +185,7 @@ func TestOrganizationStorage_Create_Abort(t *testing.T) {
 			os.rbac = mrb
 			mmemb := mock.NewMockmemberProvider(ctrl)
 			os.members = mmemb
+			os.usernamePrefix = "appuio#"
 
 			mauth.EXPECT().
 				Authorize(gomock.Any(), isAuthRequest("create")).
@@ -177,12 +198,12 @@ func TestOrganizationStorage_Create_Abort(t *testing.T) {
 
 			if tc.failRoleBinding {
 				mrb.EXPECT().
-					CreateRoleBindings(gomock.Any(), gomock.Any()).
+					CreateRoleBindings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(errors.New("")).
 					Times(1)
 			} else {
 				mrb.EXPECT().
-					CreateRoleBindings(gomock.Any(), gomock.Any()).
+					CreateRoleBindings(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil).
 					Times(1)
 				if tc.failMembers {
@@ -201,13 +222,18 @@ func TestOrganizationStorage_Create_Abort(t *testing.T) {
 			nopValidate := func(ctx context.Context, obj runtime.Object) error {
 				return nil
 			}
-			_, err := os.Create(request.WithRequestInfo(request.NewContext(),
-				&request.RequestInfo{
-					Verb:     "create",
-					APIGroup: orgv1.GroupVersion.Group,
-					Resource: "organizations",
-					Name:     "foo",
-				}),
+			_, err := os.Create(
+				request.WithUser(
+					request.WithRequestInfo(request.NewContext(),
+						&request.RequestInfo{
+							Verb:     "create",
+							APIGroup: orgv1.GroupVersion.Group,
+							Resource: "organizations",
+							Name:     "foo",
+						}),
+					&user.DefaultInfo{
+						Name: "appuio#foo",
+					}),
 				fooOrg, nopValidate, nil)
 
 			require.Error(t, err)

--- a/apiserver/organization/create_test.go
+++ b/apiserver/organization/create_test.go
@@ -46,6 +46,15 @@ func TestOrganizationStorage_Create(t *testing.T) {
 			memberName:      "smith",
 			organizationOut: fooOrg,
 		},
+		"GivenCreateOrgFromNonAPPUiOUser_ThenSuccess": {
+			userID:         "cluster-admin",
+			organizationIn: fooOrg,
+			authDecision: authResponse{
+				decision: authorizer.DecisionAllow,
+			},
+			memberName:      "",
+			organizationOut: fooOrg,
+		},
 		"GivenNsExists_ThenFail": {
 			organizationIn: fooOrg,
 			authDecision: authResponse{
@@ -216,7 +225,8 @@ func (m memberMatcher) Matches(x interface{}) bool {
 	if !ok {
 		return ok
 	}
-	return len(mem.Spec.UserRefs) > 0 && mem.Spec.UserRefs[0].Name == m.user &&
+	correctMembers := (len(mem.Spec.UserRefs) > 0 && mem.Spec.UserRefs[0].Name == m.user) || (m.user == "" && len(mem.Spec.UserRefs) == 0)
+	return correctMembers &&
 		len(mem.OwnerReferences) > 0 && mem.OwnerReferences[0].Name == m.owner
 }
 

--- a/apiserver/organization/mock/rolebindings.go
+++ b/apiserver/organization/mock/rolebindings.go
@@ -35,15 +35,15 @@ func (m *MockroleBindingCreator) EXPECT() *MockroleBindingCreatorMockRecorder {
 }
 
 // CreateRoleBindings mocks base method.
-func (m *MockroleBindingCreator) CreateRoleBindings(ctx context.Context, namespace string) error {
+func (m *MockroleBindingCreator) CreateRoleBindings(ctx context.Context, namespace, username string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRoleBindings", ctx, namespace)
+	ret := m.ctrl.Call(m, "CreateRoleBindings", ctx, namespace, username)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateRoleBindings indicates an expected call of CreateRoleBindings.
-func (mr *MockroleBindingCreatorMockRecorder) CreateRoleBindings(ctx, namespace interface{}) *gomock.Call {
+func (mr *MockroleBindingCreatorMockRecorder) CreateRoleBindings(ctx, namespace, username interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoleBindings", reflect.TypeOf((*MockroleBindingCreator)(nil).CreateRoleBindings), ctx, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoleBindings", reflect.TypeOf((*MockroleBindingCreator)(nil).CreateRoleBindings), ctx, namespace, username)
 }

--- a/apiserver/organization/organization.go
+++ b/apiserver/organization/organization.go
@@ -103,5 +103,11 @@ func userFrom(ctx context.Context, usernamePrefix string) (user.Info, bool) {
 		return nil, false
 	}
 
+	for _, u := range user.GetGroups() {
+		if u == "system:serviceaccounts" {
+			return nil, false
+		}
+	}
+
 	return user, true
 }

--- a/apiserver/organization/organization.go
+++ b/apiserver/organization/organization.go
@@ -1,7 +1,9 @@
 package organization
 
 import (
+	"context"
 	"errors"
+	"strings"
 
 	orgv1 "github.com/appuio/control-api/apis/organization/v1"
 	controlv1 "github.com/appuio/control-api/apis/v1"
@@ -9,6 +11,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
 	restbuilder "sigs.k8s.io/apiserver-runtime/pkg/builder/rest"
@@ -88,4 +92,16 @@ func convertNamespaceError(err error) error {
 		}
 	}
 	return err
+}
+
+func userFrom(ctx context.Context, usernamePrefix string) (user.Info, bool) {
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return nil, false
+	}
+	if !strings.HasPrefix(user.GetName(), usernamePrefix) {
+		return nil, false
+	}
+
+	return user, true
 }

--- a/apiserver/organization/rolebindings_test.go
+++ b/apiserver/organization/rolebindings_test.go
@@ -1,19 +1,16 @@
 package organization
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestGenerateRoleBinding(t *testing.T) {
-	rb, err := generateRoleBinding(request.WithUser(request.NewContext(), &user.DefaultInfo{
-		Name: "fooUser",
-	}), "foobar", "fooRole")
+	rb, err := generateRoleBinding(context.TODO(), "foobar", "fooUser", "fooRole")
 	require.NoError(t, err)
 	require.Len(t, rb.Subjects, 1)
 	assert.Equal(t, rbacv1.Subject{


### PR DESCRIPTION
## Summary

This prevents for example service account to unexpectedly be added as members
## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
