### PR TITLE
Implement validating admission webhook for CR users.appuio.io

### DIFF
--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: control-api
+
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,18 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appuio-io-v1-user
+  failurePolicy: Fail
+  name: validate-users.appuio.io
+  rules:
+  - apiGroups:
+    - appuio.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - users
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: control-api-controller

--- a/controller.go
+++ b/controller.go
@@ -14,6 +14,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/spf13/cobra"
 
@@ -21,6 +22,7 @@ import (
 	controlv1 "github.com/appuio/control-api/apis/v1"
 
 	"github.com/appuio/control-api/controllers"
+	"github.com/appuio/control-api/webhooks"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -113,6 +115,11 @@ func setupManager(usernamePrefix, rolePrefix string, memberRoles []string, opt c
 			return nil, err
 		}
 	}
+
+	mgr.GetWebhookServer().Register("/validate-appuio-io-v1-user", &webhook.Admission{
+		Handler: &webhooks.UserValidator{},
+	})
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/webhooks/user_webhook.go
+++ b/webhooks/user_webhook.go
@@ -15,6 +15,8 @@ import (
 
 // +kubebuilder:webhook:path=/validate-appuio-io-v1-user,mutating=false,failurePolicy=fail,groups="appuio.io",resources=users,verbs=create;update,versions=v1,name=validate-users.appuio.io,admissionReviewVersions=v1,sideEffects=None
 
+// +kubebuilder:rbac:groups=appuio.io,resources=organizationmembers,verbs=get
+
 // UserValidator holds context for the validating admission webhook for users.appuio.io
 type UserValidator struct {
 	client  client.Client

--- a/webhooks/user_webhook.go
+++ b/webhooks/user_webhook.go
@@ -1,0 +1,65 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	controlv1 "github.com/appuio/control-api/apis/v1"
+)
+
+// +kubebuilder:webhook:path=/validate-appuio-io-v1-user,mutating=false,failurePolicy=fail,groups="appuio.io",resources=users,verbs=create;update,versions=v1,name=validate-users.appuio.io,admissionReviewVersions=v1,sideEffects=None
+
+// UserValidator holds context for the validating admission webhook for users.appuio.io
+type UserValidator struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// Handle handles the users.appuio.io admission requests
+func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := log.FromContext(ctx)
+
+	user := &controlv1.User{}
+	if err := v.decoder.Decode(req, user); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	log.Info("user to validate", "user", user)
+
+	orgref := user.Spec.Preferences.DefaultOrganizationRef
+	orgMembKey := types.NamespacedName{
+		Name:      "members",
+		Namespace: orgref,
+	}
+	orgmemb := &controlv1.OrganizationMembers{}
+	if err := v.client.Get(ctx, orgMembKey, orgmemb); err != nil {
+		return admission.Denied(fmt.Sprintf("Unable to load members for organization %s", orgref))
+	}
+
+	log.Info("organization members", "orgmemb", orgmemb)
+
+	for _, orguser := range orgmemb.Spec.UserRefs {
+		if user.Name == orguser.Name {
+			return admission.Allowed("user is member of requested default organization")
+		}
+	}
+
+	return admission.Denied(fmt.Sprintf("User %s isn't member of organization %s", user.Name, orgref))
+}
+
+// InjectDecoder injects a Admission request decoder into the UserValidator
+func (v *UserValidator) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+// InjectClient injects a Kubernetes client into the UserValidator
+func (v *UserValidator) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}

--- a/webhooks/user_webhook.go
+++ b/webhooks/user_webhook.go
@@ -23,13 +23,13 @@ type UserValidator struct {
 
 // Handle handles the users.appuio.io admission requests
 func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithName("webhook.validate-users.appuio.io")
 
 	user := &controlv1.User{}
 	if err := v.decoder.Decode(req, user); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	log.Info("user to validate", "user", user)
+	log.V(4).WithValues("user", user).Info("Validating")
 
 	orgref := user.Spec.Preferences.DefaultOrganizationRef
 	orgMembKey := types.NamespacedName{
@@ -41,7 +41,7 @@ func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admis
 		return admission.Denied(fmt.Sprintf("Unable to load members for organization %s", orgref))
 	}
 
-	log.Info("organization members", "orgmemb", orgmemb)
+	log.V(4).WithValues("orgref", orgref, "orgmemb", orgmemb).Info("organizationmembers of requested default organization")
 
 	for _, orguser := range orgmemb.Spec.UserRefs {
 		if user.Name == orguser.Name {

--- a/webhooks/user_webhook_test.go
+++ b/webhooks/user_webhook_test.go
@@ -3,6 +3,7 @@ package webhooks
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,28 +37,28 @@ func TestUserValidator_Handle(t *testing.T) {
 			org:     "test-org",
 			orgmemb: []string{"test-user", "test-user-2"},
 			allowed: true,
-			errcode: 200,
+			errcode: http.StatusOK,
 		},
 		"UserIsNotMember denied": {
 			orgref:  "test-org",
 			org:     "test-org",
 			orgmemb: []string{"test-user-2", "test-user-3"},
 			allowed: false,
-			errcode: 403,
+			errcode: http.StatusForbidden,
 		},
 		"OrgDoesNotExist denied": {
 			orgref:  "test-org-2",
 			org:     "test-org",
 			orgmemb: []string{"test-user"},
 			allowed: false,
-			errcode: 403,
+			errcode: http.StatusForbidden,
 		},
 		"InvalidRequest denied": {
 			orgref:  "",
 			org:     "",
 			orgmemb: []string{"test-user"},
 			allowed: false,
-			errcode: 400, // StatusBadRequest
+			errcode: http.StatusBadRequest,
 		},
 	}
 

--- a/webhooks/user_webhook_test.go
+++ b/webhooks/user_webhook_test.go
@@ -1,0 +1,157 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	orgv1 "github.com/appuio/control-api/apis/organization/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+)
+
+func TestUserValidator_Handle(t *testing.T) {
+	ctx := context.Background()
+	tests := map[string]struct {
+		orgref  string
+		org     string
+		orgmemb []string
+		allowed bool
+		errcode int32
+	}{
+		"UserIsMember allowed": {
+			orgref:  "test-org",
+			org:     "test-org",
+			orgmemb: []string{"test-user", "test-user-2"},
+			allowed: true,
+			errcode: 200,
+		},
+		"UserIsNotMember denied": {
+			orgref:  "test-org",
+			org:     "test-org",
+			orgmemb: []string{"test-user-2", "test-user-3"},
+			allowed: false,
+			errcode: 403,
+		},
+		"OrgDoesNotExist denied": {
+			orgref:  "test-org-2",
+			org:     "test-org",
+			orgmemb: []string{"test-user"},
+			allowed: false,
+			errcode: 403,
+		},
+		"InvalidRequest denied": {
+			orgref:  "",
+			org:     "",
+			orgmemb: []string{"test-user"},
+			allowed: false,
+			errcode: 400, // StatusBadRequest
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			user := controlv1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-user",
+				},
+				Spec: controlv1.UserSpec{
+					Preferences: controlv1.UserPreferences{
+						DefaultOrganizationRef: tc.orgref,
+					},
+				},
+			}
+
+			userRefs := []controlv1.UserRef{}
+			for _, uname := range tc.orgmemb {
+				userRefs = append(userRefs, controlv1.UserRef{Name: uname})
+			}
+			orgmemb := controlv1.OrganizationMembers{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "members",
+					Namespace: tc.org,
+				},
+				Spec: controlv1.OrganizationMembersSpec{
+					UserRefs: userRefs,
+				},
+			}
+
+			uv := prepareTest(t, &user, &orgmemb)
+
+			userJson, err := json.Marshal(user)
+			require.NoError(t, err)
+			// Break admission request object JSON for
+			// InvalidRequest testcase
+			if tc.errcode == 400 {
+				userJson[10] = 'x'
+			}
+			userObj := runtime.RawExtension{
+				Raw: userJson,
+			}
+
+			admissionRequest := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "e515f52d-7181-494d-a3d3-f0738856bd97",
+					Kind: metav1.GroupVersionKind{
+						Group:   "appuio.io",
+						Version: "v1",
+						Kind:    "User",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "appuio.io",
+						Version:  "v1",
+						Resource: "users",
+					},
+					Name:      "test-user",
+					Operation: admissionv1.Update,
+					UserInfo: authenticationv1.UserInfo{
+						Username: "kubernetes-admin",
+						Groups: []string{
+							"system:masters",
+							"system:authenticated",
+						},
+					},
+					Object: userObj,
+				},
+			}
+
+			resp := uv.Handle(ctx, admissionRequest)
+
+			assert.Equal(t, tc.allowed, resp.Allowed)
+			assert.Equal(t, tc.errcode, resp.Result.Code)
+		})
+	}
+}
+
+func prepareTest(t *testing.T, initObjs ...client.Object) *UserValidator {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(orgv1.AddToScheme(scheme))
+	utilruntime.Must(controlv1.AddToScheme(scheme))
+
+	decoder, err := admission.NewDecoder(scheme)
+	require.NoError(t, err)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initObjs...).
+		Build()
+
+	uv := &UserValidator{}
+	uv.InjectClient(client)
+	uv.InjectDecoder(decoder)
+
+	return uv
+}


### PR DESCRIPTION
We use the "low-level" approach of registering our handler directly on the controller manager's webhook server as we are able to access the manager's Kubernetes client with that approach.

The client is not easily accessible when taking the "high-level" approach of implementing the `Validator` interface on the type which we want to validate.

Note that the service name and namespace in the `ValidatingWebhookConfiguration` generated by controller-gen are not configurable and need to adjusted during deployment.


## Summary

...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
