### PR TITLE
Expose controller webhook server certificate directory configuration

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -45,6 +45,7 @@ func ControllerCommand() *cobra.Command {
 	usernamePrefix := cmd.Flags().String("username-prefix", "", "Prefix prepended to username claims. Usually the same as \"--oidc-username-prefix\" of the Kubernetes API server")
 	rolePrefix := cmd.Flags().String("role-prefix", "control-api:user:", "Prefix prepended to generated cluster roles and bindings to prevent name collisions.")
 	memberRoles := cmd.Flags().StringSlice("member-roles", []string{}, "ClusterRoles to assign to every organization member for its namespace")
+	webhookCertDir := cmd.Flags().String("webhook-cert-dir", "", "Directory holding TLS certificate and key for the webhook server. If left empty, {TempDir}/k8s-webhook-server/serving-certs is used")
 
 	cmd.Run = func(*cobra.Command, []string) {
 		scheme := runtime.NewScheme()
@@ -69,6 +70,7 @@ func ControllerCommand() *cobra.Command {
 				HealthProbeBindAddress: *probeAddr,
 				LeaderElection:         *enableLeaderElection,
 				LeaderElectionID:       "d9e2acbf.control-api.appuio.io",
+				CertDir:                *webhookCertDir,
 			})
 		if err != nil {
 			setupLog.Error(err, "unable to setup manager")


### PR DESCRIPTION
## Summary

We need to be able to control the location of the controller webhook server certificate directory. See https://github.com/kubernetes-sigs/controller-runtime/blob/eb292e5d9bd6c59663fc6777ae2b99f901f386e4/pkg/manager/manager.go#L219-L224

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
