### PR TITLE
Allow User resources with no default organization

### DIFF
--- a/webhooks/user_webhook.go
+++ b/webhooks/user_webhook.go
@@ -34,6 +34,10 @@ func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admis
 	log.V(4).WithValues("user", user).Info("Validating")
 
 	orgref := user.Spec.Preferences.DefaultOrganizationRef
+	if orgref == "" {
+		// No default org is a valid config
+		return admission.Allowed("user does not have a default organization")
+	}
 	orgMembKey := types.NamespacedName{
 		Name:      "members",
 		Namespace: orgref,

--- a/webhooks/user_webhook_test.go
+++ b/webhooks/user_webhook_test.go
@@ -46,6 +46,11 @@ func TestUserValidator_Handle(t *testing.T) {
 			allowed: false,
 			errcode: http.StatusForbidden,
 		},
+		"NoOrg valid": {
+			orgref:  "",
+			allowed: true,
+			errcode: http.StatusOK,
+		},
 		"OrgDoesNotExist denied": {
 			orgref:  "test-org-2",
 			org:     "test-org",


### PR DESCRIPTION
## Summary

We should not deny Users without a default org. This currently denies our user import.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
