### PR TITLE
Fix APIServer permissions

### DIFF
--- a/apiserver/billing/rbac.go
+++ b/apiserver/billing/rbac.go
@@ -17,6 +17,9 @@ import (
 	"github.com/appuio/control-api/apiserver/billing/odoostorage"
 )
 
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;delete;patch;update;edit
+// +kubebuilder:rbac:groups=rbac.appuio.io,resources=billingentities,verbs=*
+
 // createRBACWrapper is a wrapper around the storage that creates a ClusterRole and ClusterRoleBinding for each BillingEntity on creation.
 type createRBACWrapper struct {
 	odoostorage.Storage

--- a/config/rbac/apiserver/role.yaml
+++ b/config/rbac/apiserver/role.yaml
@@ -94,7 +94,27 @@ rules:
 - apiGroups:
   - rbac.appuio.io
   resources:
+  - billingentities
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.appuio.io
+  resources:
   - organizations
+  verbs:
+  - create
+  - delete
+  - edit
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Summary

Fixes permissions so the apiserver can create clusterroles and bindings.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
