### PR TITLE
`Organization.spec.billingEntityRef` validation

### DIFF
--- a/api.go
+++ b/api.go
@@ -24,11 +24,12 @@ import (
 func APICommand() *cobra.Command {
 	roles := []string{}
 	usernamePrefix := ""
+	var allowEmptyBillingEntity bool
 
 	ob := &odooStorageBuilder{}
 
 	cmd, err := builder.APIServer.
-		WithResourceAndHandler(&orgv1.Organization{}, orgStore.New(&roles, &usernamePrefix)).
+		WithResourceAndHandler(&orgv1.Organization{}, orgStore.New(&roles, &usernamePrefix, &allowEmptyBillingEntity)).
 		WithResourceAndHandler(&billingv1.BillingEntity{}, ob.Build).
 		WithoutEtcd().
 		ExposeLoopbackAuthorizer().
@@ -40,6 +41,7 @@ func APICommand() *cobra.Command {
 	cmd.Use = "api"
 	cmd.Flags().StringSliceVar(&roles, "cluster-roles", []string{}, "Cluster Roles to bind when creating an organization")
 	cmd.Flags().StringVar(&usernamePrefix, "username-prefix", "", "Prefix prepended to username claims. Usually the same as \"--oidc-username-prefix\" of the Kubernetes API server")
+	cmd.Flags().BoolVar(&allowEmptyBillingEntity, "allow-empty-billing-entity", true, "Allow empty billing entity references")
 
 	cmd.Flags().StringVar(&ob.billingEntityStorage, "billing-entity-storage", "fake", "Storage backend for billing entities. Supported values: fake, odoo8")
 	cmd.Flags().BoolVar(&ob.billingEntityFakeMetadataSupport, "billing-entity-fake-metadata-support", false, "Enable metadata support for the fake storage backend")

--- a/apiserver/organization/billingentity_validate.go
+++ b/apiserver/organization/billingentity_validate.go
@@ -1,0 +1,73 @@
+package organization
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	restclient "k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	billingv1 "github.com/appuio/control-api/apis/billing/v1"
+	orgv1 "github.com/appuio/control-api/apis/organization/v1"
+)
+
+// +kubebuilder:rbac:groups="",resources=users;groups;serviceaccounts,verbs=impersonate
+
+// impersonator can build a client that impersonates a user
+type impersonator interface {
+	Impersonate(u user.Info) (client.Client, error)
+}
+
+// impersonatorFromRestconf can build a client that impersonates a user
+// from a rest.Config and client.Options
+type impersonatorFromRestconf struct {
+	config *restclient.Config
+	opts   client.Options
+}
+
+var _ impersonator = impersonatorFromRestconf{}
+
+// Impersonate returns a client that impersonates the given user
+func (c impersonatorFromRestconf) Impersonate(u user.Info) (client.Client, error) {
+	conf := restclient.CopyConfig(c.config)
+
+	conf.Impersonate = restclient.ImpersonationConfig{
+		UserName: u.GetName(),
+		UID:      u.GetUID(),
+		Groups:   u.GetGroups(),
+		Extra:    u.GetExtra(),
+	}
+	return client.New(conf, c.opts)
+}
+
+// billingEntityValidator validates that the billing entity exists and the requesting user has access to it.
+// it does so by impersonating the user and trying to get the billing entity.
+func (s *organizationStorage) billingEntityValidator(ctx context.Context, org, oldOrg *orgv1.Organization) error {
+	// check if changed
+	if oldOrg != nil && oldOrg.Spec.BillingEntityRef == org.Spec.BillingEntityRef {
+		return nil
+	}
+	// check if we allow empty billing entities
+	if org.Spec.BillingEntityRef == "" && s.allowEmptyBillingEntity {
+		return nil
+	}
+
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return fmt.Errorf("no user in context")
+	}
+
+	var be billingv1.BillingEntity
+	c, err := s.impersonator.Impersonate(user)
+	if err != nil {
+		return fmt.Errorf("failed to impersonate user: %w", err)
+	}
+
+	if err := c.Get(ctx, client.ObjectKey{Name: org.Spec.BillingEntityRef}, &be); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/apiserver/organization/create.go
+++ b/apiserver/organization/create.go
@@ -25,6 +25,9 @@ func (s *organizationStorage) Create(ctx context.Context, obj runtime.Object, cr
 	if err := createValidation(ctx, obj); err != nil {
 		return nil, err
 	}
+	if err := s.billingEntityValidator(ctx, org, nil); err != nil {
+		return nil, fmt.Errorf("failed to validate billing entity reference: %w", err)
+	}
 
 	return s.create(ctx, org, options)
 }

--- a/apiserver/organization/create_test.go
+++ b/apiserver/organization/create_test.go
@@ -48,6 +48,33 @@ func TestOrganizationStorage_Create(t *testing.T) {
 			memberName:      "smith",
 			organizationOut: fooOrg,
 		},
+		"GivenCreateOrgValidBillingEntity_ThenSuccess": {
+			userID: "appuio#smith",
+			organizationIn: func() *orgv1.Organization {
+				fooOrg := fooOrg.DeepCopy()
+				fooOrg.Spec.BillingEntityRef = "foo"
+				return fooOrg
+			}(),
+			authDecision: authResponse{
+				decision: authorizer.DecisionAllow,
+			},
+			memberName:      "smith",
+			organizationOut: fooOrg,
+		},
+		"GivenCreateOrgInvalidBillingEntity_ThenFail": {
+			userID: "appuio#smith",
+			organizationIn: func() *orgv1.Organization {
+				fooOrg := fooOrg.DeepCopy()
+				fooOrg.Spec.BillingEntityRef = "blub"
+				return fooOrg
+			}(),
+			authDecision: authResponse{
+				decision: authorizer.DecisionAllow,
+			},
+			memberName:       "smith",
+			err:              errors.New("failed to validate billing entity reference: billingentities.billing.appuio.io \"blub\" not found"),
+			skipRoleBindings: true,
+		},
 		"GivenCreateOrgFromNonAPPUiOUser_ThenSuccessButNoSA": {
 			userID:         "cluster-admin",
 			organizationIn: fooOrg,

--- a/apiserver/organization/organization_test.go
+++ b/apiserver/organization/organization_test.go
@@ -9,11 +9,16 @@ import (
 	mock "github.com/appuio/control-api/apiserver/organization/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	billingv1 "github.com/appuio/control-api/apis/billing/v1"
 	orgv1 "github.com/appuio/control-api/apis/organization/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
@@ -23,7 +28,9 @@ func newMockedOrganizationStorage(t *testing.T, ctrl *gomock.Controller) (authwr
 	mnp := mock.NewMocknamespaceProvider(ctrl)
 	mauth := authmock.NewMockAuthorizer(ctrl)
 	os, err := authwrapper.NewAuthorizedStorage(&organizationStorage{
-		namepaces: mnp,
+		namepaces:               mnp,
+		allowEmptyBillingEntity: true,
+		impersonator:            &fakeImpersonator{t},
 	}, metav1.GroupVersionResource{
 		Group:    orgv1.GroupVersion.Group,
 		Version:  orgv1.GroupVersion.Version,
@@ -108,4 +115,28 @@ func (m authRequestMatcher) String() string {
 
 func isAuthRequest(verb string) authRequestMatcher {
 	return authRequestMatcher{verb: verb}
+}
+
+type fakeImpersonator struct{ t *testing.T }
+
+func (c fakeImpersonator) Impersonate(u user.Info) (client.Client, error) {
+	c.t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(c.t, billingv1.AddToScheme(scheme))
+
+	objs := []runtime.Object{
+		&billingv1.BillingEntity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		&billingv1.BillingEntity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+		},
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build(), nil
 }

--- a/config/rbac/apiserver/role.yaml
+++ b/config/rbac/apiserver/role.yaml
@@ -18,6 +18,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - groups
+  - serviceaccounts
+  - users
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create


### PR DESCRIPTION
## Summary

Uses impersonation to check if a user can get a billing entity when referencing it in an Organization.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
