### PR TITLE
Fix list permission on BillingEntity/Invitation (+ redeem)

### DIFF
--- a/config/user-rbac/basic-user-role.yml
+++ b/config/user-rbac/basic-user-role.yml
@@ -3,12 +3,20 @@ kind: ClusterRole
 metadata:
   name: control-api:basic-user
 rules:
-- apiGroups: ["organization.appuio.io"] 
+- apiGroups: ["organization.appuio.io"]
   resources: ["organizations"]
   verbs: ["get", "watch", "list", "patch", "update", "create"]
-- apiGroups: ["rbac.appuio.io"] 
+- apiGroups: ["rbac.appuio.io"]
   resources: ["organizations"]
   verbs: ["watch", "list", "create"]
-- apiGroups: ["appuio.io"] 
+- apiGroups: ["appuio.io"]
   resources: ["zones"]
+  verbs: ["get", "watch", "list"]
+# BillingEntity
+# `get` permissions are created manually or when creating a new BillingEntity
+- apiGroups: ["rbac.appuio.io"]
+  resources: ["billingentities"]
+  verbs: ["watch", "list"]
+- apiGroups: ["billing.appuio.io"]
+  resources: ["billingentities"]
   verbs: ["get", "watch", "list"]

--- a/config/user-rbac/basic-user-role.yml
+++ b/config/user-rbac/basic-user-role.yml
@@ -20,3 +20,11 @@ rules:
 - apiGroups: ["billing.appuio.io"]
   resources: ["billingentities"]
   verbs: ["get", "watch", "list"]
+# Invitation
+# `get` permissions are created when creating a new BillingEntity
+- apiGroups: ["rbac.appuio.io"]
+  resources: ["invitations"]
+  verbs: ["watch", "list", "redeem"]
+- apiGroups: ["user.appuio.io"]
+  resources: ["invitations"]
+  verbs: ["get", "watch", "list", "redeem"]


### PR DESCRIPTION
## Summary

Fixes listing billing entities/invitations for users that are allowed to `get` billing entities/invitations.

BEs/Inviations are filtered further by `get` for `list`, and `watch` in the aggregate API server.

Allows authenticated users to redeem invitations. They are guarded by token.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
