### PR TITLE
Validate invitation targetRefs to prevent privilege escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ kubectl patch validatingwebhookconfiguration validating-webhook-configuration \
   -p '{
     "webhooks": [
       {
+        "name": "validate-invitations.user.appuio.io",
+        "clientConfig": {
+          "caBundle": "'"$(base64 -w0 "./local-env/webhook-certs/tls.crt)"'",
+          "service": {
+            "namespace": "default",
+            "port": 9444
+          }
+        }
+      },
+      {
         "name": "validate-users.appuio.io",
         "clientConfig": {
           "caBundle": "'"$(base64 -w0 "./local-env/webhook-certs/tls.crt)"'",

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,6 +11,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-user-appuio-io-v1-invitation
+  failurePolicy: Fail
+  name: validate-invitations.user.appuio.io
+  rules:
+  - apiGroups:
+    - user.appuio.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - invitations
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-appuio-io-v1-user
   failurePolicy: Fail
   name: validate-users.appuio.io

--- a/controllers/invitation_redeem_controller.go
+++ b/controllers/invitation_redeem_controller.go
@@ -3,10 +3,8 @@ package controllers
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"go.uber.org/multierr"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -15,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	userv1 "github.com/appuio/control-api/apis/user/v1"
-	controlv1 "github.com/appuio/control-api/apis/v1"
+	"github.com/appuio/control-api/controllers/targetref"
 )
 
 // InvitationRedeemReconciler reconciles invitations and adds a token to the status if required.
@@ -89,72 +87,20 @@ func (r *InvitationRedeemReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func addUserToTarget(ctx context.Context, c client.Client, user string, target userv1.TargetRef) error {
-	switch {
-	case target.APIGroup == "appuio.io" && target.Kind == "OrganizationMembers":
-		om := controlv1.OrganizationMembers{}
-		if err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, &om); err != nil {
-			return err
-		}
-		refs, added := ensure(om.Spec.UserRefs, controlv1.UserRef{Name: user})
-		om.Spec.UserRefs = refs
-		if added {
-			return c.Update(ctx, &om)
-		}
-		return nil
-	case target.APIGroup == "appuio.io" && target.Kind == "Team":
-		te := controlv1.Team{}
-		if err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, &te); err != nil {
-			return err
-		}
-		refs, added := ensure(te.Spec.UserRefs, controlv1.UserRef{Name: user})
-		te.Spec.UserRefs = refs
-		if added {
-			return c.Update(ctx, &te)
-		}
-		return nil
-	case target.APIGroup == rbacv1.GroupName && target.Kind == "ClusterRoleBinding":
-		crb := rbacv1.ClusterRoleBinding{}
-		if err := c.Get(ctx, client.ObjectKey{Name: target.Name}, &crb); err != nil {
-			return err
-		}
-		subjects, added := ensure(crb.Subjects, newSubject(user))
-		crb.Subjects = subjects
-		if added {
-			return c.Update(ctx, &crb)
-		}
-		return nil
-	case target.APIGroup == rbacv1.GroupName && target.Kind == "RoleBinding":
-		rb := rbacv1.RoleBinding{}
-		if err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, &rb); err != nil {
-			return err
-		}
-		subjects, added := ensure(rb.Subjects, newSubject(user))
-		rb.Subjects = subjects
-		if added {
-			return c.Update(ctx, &rb)
-		}
-		return nil
+	o, err := targetref.GetTarget(ctx, c, target)
+	if err != nil {
+		return err
 	}
 
-	return fmt.Errorf("unsupported target %q.%q", target.APIGroup, target.Kind)
-}
-
-// ensure ensures that the given element is present in the given slice.
-// If the element is already present, the original slice is returned.
-// If the element is not present, a new slice is returned with the element appended.
-func ensure[T comparable](s []T, e T) (ret []T, added bool) {
-	for _, v := range s {
-		if v == e {
-			return s, false
-		}
+	a, err := targetref.NewUserAccessor(o)
+	if err != nil {
+		return err
 	}
-	return append(s, e), true
-}
 
-func newSubject(user string) rbacv1.Subject {
-	return rbacv1.Subject{
-		Kind:     rbacv1.UserKind,
-		APIGroup: rbacv1.GroupName,
-		Name:     user,
+	added := a.EnsureUser(user)
+	if added {
+		return c.Update(ctx, o)
 	}
+
+	return nil
 }

--- a/controllers/targetref/targetref.go
+++ b/controllers/targetref/targetref.go
@@ -1,0 +1,114 @@
+package targetref
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+)
+
+// GetTarget returns the target object for the given TargetRef.
+// Returns an error if the target is not supported.
+func GetTarget(ctx context.Context, c client.Client, target userv1.TargetRef) (client.Object, error) {
+	var obj client.Object
+	switch {
+	case target.APIGroup == "appuio.io" && target.Kind == "OrganizationMembers":
+		obj = &controlv1.OrganizationMembers{}
+	case target.APIGroup == "appuio.io" && target.Kind == "Team":
+		obj = &controlv1.Team{}
+	case target.APIGroup == rbacv1.GroupName && target.Kind == "ClusterRoleBinding":
+		obj = &rbacv1.ClusterRoleBinding{}
+	case target.APIGroup == rbacv1.GroupName && target.Kind == "RoleBinding":
+		obj = &rbacv1.RoleBinding{}
+	default:
+		return nil, fmt.Errorf("unsupported target %q.%q", target.APIGroup, target.Kind)
+	}
+
+	err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, obj)
+	return obj, err
+}
+
+// UserAccessor is an interface for accessing users from objects supported by this project.
+type UserAccessor interface {
+	// EnsureUser adds the user to the object if it is not already present.
+	// Returns true if the user was added.
+	EnsureUser(user string) (added bool)
+	// HasUser returns true if the user is present in the object.
+	HasUser(user string) bool
+}
+
+// NewUserAccessor returns a UserAccessor for the given object or an error if the object is not supported.
+func NewUserAccessor(obj client.Object) (UserAccessor, error) {
+	switch o := obj.(type) {
+	case *controlv1.OrganizationMembers:
+		return &controlv1UserRefAccessor{userRefs: &o.Spec.UserRefs}, nil
+	case *controlv1.Team:
+		return &controlv1UserRefAccessor{userRefs: &o.Spec.UserRefs}, nil
+	case *rbacv1.ClusterRoleBinding:
+		return &rbacv1SubjectAccessor{subjects: &o.Subjects}, nil
+	case *rbacv1.RoleBinding:
+		return &rbacv1SubjectAccessor{subjects: &o.Subjects}, nil
+	default:
+		return nil, fmt.Errorf("unsupported object %T", obj)
+	}
+}
+
+type controlv1UserRefAccessor struct {
+	userRefs *[]controlv1.UserRef
+}
+
+var _ UserAccessor = &controlv1UserRefAccessor{}
+
+func (s *controlv1UserRefAccessor) HasUser(user string) bool {
+	return isInSlice(*s.userRefs, controlv1.UserRef{Name: user})
+}
+
+func (s *controlv1UserRefAccessor) EnsureUser(user string) (added bool) {
+	*s.userRefs, added = ensure(*s.userRefs, controlv1.UserRef{Name: user})
+	return
+}
+
+type rbacv1SubjectAccessor struct {
+	subjects *[]rbacv1.Subject
+}
+
+var _ UserAccessor = &rbacv1SubjectAccessor{}
+
+func (s *rbacv1SubjectAccessor) HasUser(user string) bool {
+	return isInSlice(*s.subjects, newSubject(user))
+}
+
+func (s *rbacv1SubjectAccessor) EnsureUser(user string) (added bool) {
+	*s.subjects, added = ensure(*s.subjects, newSubject(user))
+	return
+}
+
+func newSubject(user string) rbacv1.Subject {
+	return rbacv1.Subject{
+		Kind:     rbacv1.UserKind,
+		APIGroup: rbacv1.GroupName,
+		Name:     user,
+	}
+}
+
+func ensure[T comparable](s []T, e T) (ret []T, added bool) {
+	for _, v := range s {
+		if v == e {
+			return s, false
+		}
+	}
+	return append(s, e), true
+}
+
+func isInSlice[T comparable](s []T, e T) (found bool) {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/targetref/targetref_test.go
+++ b/controllers/targetref/targetref_test.go
@@ -1,0 +1,143 @@
+package targetref_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+	"github.com/appuio/control-api/controllers/targetref"
+)
+
+func Test_GetTarget(t *testing.T) {
+	tt := []client.Object{
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		&controlv1.OrganizationMembers{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		&controlv1.Team{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+	}
+
+	for _, obj := range tt {
+		t.Run(fmt.Sprintf("%T", obj), func(t *testing.T) {
+			c := newClient(t)
+			require.NoError(t, c.Create(context.Background(), obj))
+			// Fill type meta
+			require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(obj), obj))
+
+			getObj, err := targetref.GetTarget(context.Background(), c, userv1.TargetRef{
+				APIGroup:  obj.GetObjectKind().GroupVersionKind().Group,
+				Kind:      obj.GetObjectKind().GroupVersionKind().Kind,
+				Name:      obj.GetName(),
+				Namespace: obj.GetNamespace(),
+			})
+			require.NoError(t, err)
+			require.IsType(t, obj, getObj)
+		})
+	}
+}
+
+func Test_GetTarget_UnsupportedType(t *testing.T) {
+	_, err := targetref.GetTarget(context.Background(), nil, userv1.TargetRef{
+		APIGroup: "apps/v1",
+		Kind:     "Deployment",
+	})
+	require.ErrorContains(t, err, "unsupported target")
+	require.ErrorContains(t, err, "Deployment")
+}
+
+func Test_UserAccessor_AccessUser(t *testing.T) {
+	tt := []client.Object{
+		&rbacv1.ClusterRoleBinding{
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:     rbacv1.UserKind,
+					APIGroup: rbacv1.GroupName,
+					Name:     "user1",
+				},
+			},
+		},
+		&rbacv1.RoleBinding{
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:     rbacv1.UserKind,
+					APIGroup: rbacv1.GroupName,
+					Name:     "user1",
+				},
+			},
+		},
+		&controlv1.OrganizationMembers{
+			Spec: controlv1.OrganizationMembersSpec{
+				UserRefs: []controlv1.UserRef{
+					{Name: "user1"},
+				},
+			},
+		},
+		&controlv1.Team{
+			Spec: controlv1.TeamSpec{
+				UserRefs: []controlv1.UserRef{
+					{Name: "user1"},
+				},
+			},
+		},
+	}
+
+	for _, obj := range tt {
+		t.Run(fmt.Sprintf("%T", obj), func(t *testing.T) {
+			a, err := targetref.NewUserAccessor(obj)
+			require.NoError(t, err)
+
+			require.False(t, a.HasUser("user2"))
+			require.True(t, a.EnsureUser("user2"))
+			require.True(t, a.HasUser("user2"))
+			require.False(t, a.EnsureUser("user2"))
+			require.True(t, a.HasUser("user2"))
+		})
+	}
+}
+
+func Test_UserAccessor_UnsupportedType(t *testing.T) {
+	_, err := targetref.NewUserAccessor(&rbacv1.Role{})
+	require.Error(t, err)
+}
+
+func newClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, controlv1.AddToScheme(scheme))
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+}

--- a/local-env/setup-kind.sh
+++ b/local-env/setup-kind.sh
@@ -137,6 +137,12 @@ kubectl patch validatingwebhookconfiguration validating-webhook-configuration \
         "clientConfig": {
           "caBundle": "'"$(eval $base64_no_wrap < "${script_dir}"/webhook-certs/tls.crt)"'"
         }
+      },
+      {
+        "name": "validate-invitations.user.appuio.io",
+        "clientConfig": {
+          "caBundle": "'"$(eval $base64_no_wrap < "${script_dir}"/webhook-certs/tls.crt)"'"
+        }
       }
     ]
   }'

--- a/webhooks/invitation_webhook.go
+++ b/webhooks/invitation_webhook.go
@@ -1,0 +1,114 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/multierr"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+)
+
+// +kubebuilder:webhook:path=/validate-user-appuio-io-v1-invitation,mutating=false,failurePolicy=fail,groups="user.appuio.io",resources=invitations,verbs=create;update,versions=v1,name=validate-invitations.user.appuio.io,admissionReviewVersions=v1,sideEffects=None
+
+// InvitationValidator holds context for the validating admission webhook for users.appuio.io
+type InvitationValidator struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// Handle handles the users.appuio.io admission requests
+func (v *InvitationValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := log.FromContext(ctx).WithName("validate-invitations.user.appuio.io")
+
+	inv := &userv1.Invitation{}
+	if err := v.decoder.Decode(req, inv); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	log.V(4).WithValues("invitation", inv).Info("Validating")
+
+	username := req.UserInfo.Username
+	authErrors := make([]error, 0, len(inv.Spec.TargetRefs))
+	for _, target := range inv.Spec.TargetRefs {
+		authErrors = append(authErrors, authorizeTarget(ctx, v.client, username, target))
+	}
+	if err := multierr.Combine(authErrors...); err != nil {
+		return admission.Denied(fmt.Sprintf("user %q is not allowed to invite to the targets: %s", username, err))
+	}
+
+	return admission.Allowed("target refs are valid")
+}
+
+// InjectDecoder injects a Admission request decoder into the InvitationValidator
+func (v *InvitationValidator) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}
+
+// InjectClient injects a Kubernetes client into the InvitationValidator
+func (v *InvitationValidator) InjectClient(c client.Client) error {
+	v.client = c
+	return nil
+}
+
+func authorizeTarget(ctx context.Context, c client.Client, user string, target userv1.TargetRef) error {
+	switch {
+	case target.APIGroup == "appuio.io" && target.Kind == "OrganizationMembers":
+		om := controlv1.OrganizationMembers{}
+		if err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, &om); err != nil {
+			return err
+		}
+		if isInSlice(om.Spec.UserRefs, controlv1.UserRef{Name: user}) {
+			return nil
+		}
+	case target.APIGroup == "appuio.io" && target.Kind == "Team":
+		te := controlv1.Team{}
+		if err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, &te); err != nil {
+			return err
+		}
+		if isInSlice(te.Spec.UserRefs, controlv1.UserRef{Name: user}) {
+			return nil
+		}
+	case target.APIGroup == rbacv1.GroupName && target.Kind == "ClusterRoleBinding":
+		crb := rbacv1.ClusterRoleBinding{}
+		if err := c.Get(ctx, client.ObjectKey{Name: target.Name}, &crb); err != nil {
+			return err
+		}
+		if isInSlice(crb.Subjects, newSubject(user)) {
+			return nil
+		}
+	case target.APIGroup == rbacv1.GroupName && target.Kind == "RoleBinding":
+		rb := rbacv1.RoleBinding{}
+		if err := c.Get(ctx, client.ObjectKey{Name: target.Name, Namespace: target.Namespace}, &rb); err != nil {
+			return err
+		}
+		if isInSlice(rb.Subjects, newSubject(user)) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("target %q.%q/%q in namespace %q is not allowed", target.APIGroup, target.Kind, target.Name, target.Namespace)
+}
+
+func isInSlice[T comparable](s []T, e T) (found bool) {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}
+
+func newSubject(user string) rbacv1.Subject {
+	return rbacv1.Subject{
+		Kind:     rbacv1.UserKind,
+		APIGroup: rbacv1.GroupName,
+		Name:     user,
+	}
+}

--- a/webhooks/invitation_webhook_test.go
+++ b/webhooks/invitation_webhook_test.go
@@ -1,0 +1,359 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	orgv1 "github.com/appuio/control-api/apis/organization/v1"
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+)
+
+func TestInvitationValidator_Handle(t *testing.T) {
+	// allowed user is a member of possible targets
+	const allowedUser = "allowed-user"
+	// denied user is not a member of possible targets
+	const deniedUser = "denied-user"
+
+	const (
+		testOrg      = "foo-org"
+		testTeam     = "foo-team"
+		testRoleName = "foo-role"
+	)
+
+	tests := map[string]struct {
+		requestUser string
+		targets     []userv1.TargetRef
+
+		allowed bool
+		errcode int32
+	}{
+		"empty is allowed": {
+			requestUser: deniedUser,
+			targets:     []userv1.TargetRef{},
+			allowed:     true,
+			errcode:     http.StatusOK,
+		},
+
+		"unknown target is denied": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "custom.io",
+					Kind:      "MyCustomKind",
+					Namespace: testOrg,
+					Name:      "custom",
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"invalid request": {
+			requestUser: allowedUser,
+			targets:     []userv1.TargetRef{},
+			allowed:     false,
+			errcode:     http.StatusBadRequest,
+		},
+
+		"OrganizationMembers allowed": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "appuio.io",
+					Kind:      "OrganizationMembers",
+					Namespace: testOrg,
+					Name:      "members",
+				},
+			},
+			allowed: true,
+			errcode: http.StatusOK,
+		},
+
+		"OrganizationMembers denied": {
+			requestUser: deniedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "appuio.io",
+					Kind:      "OrganizationMembers",
+					Namespace: testOrg,
+					Name:      "members",
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"OrganizationMembers not found, denied": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "appuio.io",
+					Kind:      "OrganizationMembers",
+					Namespace: testOrg,
+					Name:      "members" + "-not-found",
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"Team allowed": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "appuio.io",
+					Kind:      "Team",
+					Namespace: testOrg,
+					Name:      testTeam,
+				},
+			},
+			allowed: true,
+			errcode: http.StatusOK,
+		},
+
+		"Team denied": {
+			requestUser: deniedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "appuio.io",
+					Kind:      "Team",
+					Namespace: testOrg,
+					Name:      testTeam,
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"Team not found, denied": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  "appuio.io",
+					Kind:      "Team",
+					Namespace: testOrg,
+					Name:      testTeam + "-not-found",
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"ClusterRoleBinding allowed": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRoleBinding",
+					Name:     testRoleName,
+				},
+			},
+			allowed: true,
+			errcode: http.StatusOK,
+		},
+
+		"ClusterRoleBinding denied": {
+			requestUser: deniedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRoleBinding",
+					Name:     testRoleName,
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"ClusterRoleBinding not found, denied": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRoleBinding",
+					Name:     testRoleName + "-not-found",
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"RoleBinding allowed": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  rbacv1.GroupName,
+					Kind:      "RoleBinding",
+					Namespace: testOrg,
+					Name:      testRoleName,
+				},
+			},
+			allowed: true,
+			errcode: http.StatusOK,
+		},
+
+		"RoleBinding denied": {
+			requestUser: deniedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  rbacv1.GroupName,
+					Kind:      "RoleBinding",
+					Namespace: testOrg,
+					Name:      testRoleName,
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+
+		"RoleBinding not found, denied": {
+			requestUser: allowedUser,
+			targets: []userv1.TargetRef{
+				{
+					APIGroup:  rbacv1.GroupName,
+					Kind:      "RoleBinding",
+					Namespace: testOrg,
+					Name:      testRoleName + "-not-found",
+				},
+			},
+			allowed: false,
+			errcode: http.StatusForbidden,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invitation := userv1.Invitation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-invitation",
+				},
+				Spec: userv1.InvitationSpec{
+					TargetRefs: tc.targets,
+				},
+			}
+
+			org := controlv1.OrganizationMembers{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "members",
+					Namespace: testOrg,
+				},
+				Spec: controlv1.OrganizationMembersSpec{
+					UserRefs: []controlv1.UserRef{{Name: allowedUser}},
+				},
+			}
+			team := controlv1.Team{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testTeam,
+					Namespace: testOrg,
+				},
+				Spec: controlv1.TeamSpec{
+					UserRefs: []controlv1.UserRef{{Name: allowedUser}},
+				},
+			}
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testOrg,
+					Name:      testRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     rbacv1.UserKind,
+						APIGroup: rbacv1.GroupName,
+						Name:     allowedUser,
+					},
+				},
+			}
+			crb := rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:     rbacv1.UserKind,
+						APIGroup: rbacv1.GroupName,
+						Name:     allowedUser,
+					},
+				},
+			}
+
+			iv := prepareInvitationValidatorTest(t, &invitation, &org, &team, &rb, &crb)
+
+			invJson, err := json.Marshal(invitation)
+			require.NoError(t, err)
+			// Break admission request object JSON for
+			// InvalidRequest testcase
+			if tc.errcode == http.StatusBadRequest {
+				invJson[10] = 'x'
+			}
+			invObj := runtime.RawExtension{
+				Raw: invJson,
+			}
+
+			admissionRequest := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID: "e515f52d-7181-494d-a3d3-f0738856bd97",
+					Kind: metav1.GroupVersionKind{
+						Group:   "appuio.io",
+						Version: "v1",
+						Kind:    "Invitation",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "user.appuio.io",
+						Version:  "v1",
+						Resource: "invitations",
+					},
+					Name:      "test-user",
+					Operation: admissionv1.Update,
+					UserInfo: authenticationv1.UserInfo{
+						Username: tc.requestUser,
+					},
+					Object: invObj,
+				},
+			}
+
+			resp := iv.Handle(context.Background(), admissionRequest)
+
+			assert.Equal(t, tc.allowed, resp.Allowed)
+			assert.Equal(t, tc.errcode, resp.Result.Code)
+		})
+	}
+}
+
+func prepareInvitationValidatorTest(t *testing.T, initObjs ...client.Object) *InvitationValidator {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(orgv1.AddToScheme(scheme))
+	utilruntime.Must(controlv1.AddToScheme(scheme))
+	utilruntime.Must(userv1.AddToScheme(scheme))
+
+	decoder, err := admission.NewDecoder(scheme)
+	require.NoError(t, err)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initObjs...).
+		Build()
+
+	iv := &InvitationValidator{}
+	iv.InjectClient(client)
+	iv.InjectDecoder(decoder)
+
+	return iv
+}

--- a/webhooks/user_webhook_test.go
+++ b/webhooks/user_webhook_test.go
@@ -94,7 +94,7 @@ func TestUserValidator_Handle(t *testing.T) {
 				},
 			}
 
-			uv := prepareTest(t, &user, &orgmemb)
+			uv := prepareUserValidatorTest(t, &user, &orgmemb)
 
 			userJson, err := json.Marshal(user)
 			require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestUserValidator_Handle(t *testing.T) {
 	}
 }
 
-func prepareTest(t *testing.T, initObjs ...client.Object) *UserValidator {
+func prepareUserValidatorTest(t *testing.T, initObjs ...client.Object) *UserValidator {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(orgv1.AddToScheme(scheme))


### PR DESCRIPTION
A user creating or updating an Invitation must be referenced in the object he is trying to create an invitation for.

Only direct user memberships are tested since there is not yet a concept for groups in the control API.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
