### PR TITLE
Remove expired and redeemed invites

### DIFF
--- a/config/rbac/controller/role.yaml
+++ b/config/rbac/controller/role.yaml
@@ -114,6 +114,7 @@ rules:
   resources:
   - invitations
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -187,6 +188,7 @@ rules:
   resources:
   - invitations
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/controllers/invitation_cleanup_controller.go
+++ b/controllers/invitation_cleanup_controller.go
@@ -1,0 +1,83 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+)
+
+// InvitationCleanupReconciler reconciles invitations, deleting them if appropriate
+type InvitationCleanupReconciler struct {
+	client.Client
+
+	Recorder record.EventRecorder
+	Scheme   *runtime.Scheme
+
+	RedeemedInvitationTTL time.Duration
+}
+
+//+kubebuilder:rbac:groups="rbac.appuio.io",resources=invitations,verbs=get;list;watch
+//+kubebuilder:rbac:groups="user.appuio.io",resources=invitations,verbs=get;list;watch
+//+kubebuilder:rbac:groups="rbac.appuio.io",resources=invitations/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups="user.appuio.io",resources=invitations/status,verbs=get;update;patch
+
+// Reconcile reacts on invitations and removes them if required
+func (r *InvitationCleanupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+	log.V(4).WithValues("request", req).Info("Reconciling")
+
+	log.V(4).Info("Getting the Invitation...")
+	inv := userv1.Invitation{}
+	if err := r.Get(ctx, req.NamespacedName, &inv); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !inv.ObjectMeta.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	if inv.Status.Token == "" {
+		// Invitation is not yet valid
+		return ctrl.Result{}, nil
+	}
+	now := metav1.NewTime(time.Now())
+
+	if inv.IsRedeemed() {
+		cond := apimeta.FindStatusCondition(inv.Status.Conditions, userv1.ConditionRedeemed)
+		ttlExpirationTime := cond.LastTransitionTime.Add(r.RedeemedInvitationTTL)
+		if ttlExpirationTime.Before(now.Time) {
+			log.V(4).Info("Redeemed Invitation TTL expired - deleting", "ttlExpirationTime", ttlExpirationTime)
+			return r.DeleteInvitation(ctx, inv)
+		}
+		return ctrl.Result{RequeueAfter: ttlExpirationTime.Sub(now.Add(-time.Minute))}, nil
+	} else {
+		if inv.Status.ValidUntil.Before(&now) {
+			log.V(4).Info("Invitation expired - deleting")
+			return r.DeleteInvitation(ctx, inv)
+		}
+	}
+	return ctrl.Result{RequeueAfter: inv.Status.ValidUntil.Sub(now.Add(-time.Minute))}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *InvitationCleanupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&userv1.Invitation{}).
+		Complete(r)
+}
+
+func (r *InvitationCleanupReconciler) DeleteInvitation(ctx context.Context, inv userv1.Invitation) (ctrl.Result, error) {
+	if err := r.Delete(ctx, &inv); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}

--- a/controllers/invitation_cleanup_controller_test.go
+++ b/controllers/invitation_cleanup_controller_test.go
@@ -1,0 +1,164 @@
+package controllers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+	. "github.com/appuio/control-api/controllers"
+)
+
+func Test_InvitationCleanupReconciler_Reconcile_Redeemed_Success(t *testing.T) {
+	ctx := context.Background()
+
+	subject := userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "subject",
+		},
+	}
+	subject.Status.Token = uuid.New().String()
+	subject.Status.ValidUntil = metav1.NewTime(time.Now().Add(-time.Minute))
+	apimeta.SetStatusCondition(&subject.Status.Conditions, metav1.Condition{
+		Type:   userv1.ConditionRedeemed,
+		Status: metav1.ConditionTrue,
+	})
+
+	c := prepareTest(t, &subject)
+
+	_, err := (&InvitationCleanupReconciler{
+		Client:                c,
+		Scheme:                c.Scheme(),
+		Recorder:              record.NewFakeRecorder(3),
+		RedeemedInvitationTTL: time.Hour,
+	}).Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: subject.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject))
+}
+
+func Test_InvitationCleanupReconciler_Reconcile_RedeemedAndExpired_Success(t *testing.T) {
+	ctx := context.Background()
+
+	subject := userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "subject",
+		},
+	}
+	subject.Status.Token = uuid.New().String()
+	subject.Status.ValidUntil = metav1.NewTime(time.Now().Add(time.Minute))
+	apimeta.SetStatusCondition(&subject.Status.Conditions, metav1.Condition{
+		Type:   userv1.ConditionRedeemed,
+		Status: metav1.ConditionTrue,
+	})
+
+	c := prepareTest(t, &subject)
+
+	_, err := (&InvitationCleanupReconciler{
+		Client:                c,
+		Scheme:                c.Scheme(),
+		Recorder:              record.NewFakeRecorder(3),
+		RedeemedInvitationTTL: -time.Hour,
+	}).Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: subject.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	require.ErrorContains(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject), "not found")
+}
+
+func Test_InvitationCleanupReconciler_Reconcile_Expired_Success(t *testing.T) {
+	ctx := context.Background()
+
+	subject := userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "subject",
+		},
+	}
+	subject.Status.Token = uuid.New().String()
+	subject.Status.ValidUntil = metav1.NewTime(time.Now().Add(time.Duration(-1) * time.Minute))
+
+	c := prepareTest(t, &subject)
+
+	_, err := (&InvitationCleanupReconciler{
+		Client:                c,
+		Scheme:                c.Scheme(),
+		Recorder:              record.NewFakeRecorder(3),
+		RedeemedInvitationTTL: time.Hour,
+	}).Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: subject.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	require.ErrorContains(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject), "not found")
+}
+
+func Test_InvitationCleanupReconciler_Reconcile_Valid_Success(t *testing.T) {
+	ctx := context.Background()
+
+	subject := userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "subject",
+		},
+	}
+	subject.Status.Token = uuid.New().String()
+	subject.Status.ValidUntil = metav1.NewTime(time.Now().Add(time.Minute))
+
+	c := prepareTest(t, &subject)
+
+	_, err := (&InvitationCleanupReconciler{
+		Client:                c,
+		Scheme:                c.Scheme(),
+		Recorder:              record.NewFakeRecorder(3),
+		RedeemedInvitationTTL: time.Hour,
+	}).Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: subject.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject))
+}
+
+func Test_InvitationCleanupReconciler_Reconcile_Uninitialized_Success(t *testing.T) {
+	ctx := context.Background()
+
+	subject := userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "subject",
+		},
+	}
+
+	c := prepareTest(t, &subject)
+
+	_, err := (&InvitationCleanupReconciler{
+		Client:                c,
+		Scheme:                c.Scheme(),
+		Recorder:              record.NewFakeRecorder(3),
+		RedeemedInvitationTTL: time.Hour,
+	}).Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: subject.Name,
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject))
+}


### PR DESCRIPTION
## Summary

Adds a new controller which takes care of removing invites that are expired, or have been redeemed for a certain amount of time (default 30 days).

...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
