### PR TITLE
Switch passing invitation token from path to url.Values

### DIFF
--- a/apiserver/user/invitation_redeem.go
+++ b/apiserver/user/invitation_redeem.go
@@ -41,8 +41,7 @@ func (ir *invitationRedeemer) ConnectMethods() []string {
 }
 
 func (ir *invitationRedeemer) NewConnectOptions() (runtime.Object, bool, string) {
-	// Adds the token from the path to the options under the field "token"
-	return &userv1.RedeemOptions{}, true, "token"
+	return &userv1.RedeemOptions{}, false, ""
 }
 
 // Connect implements the REDEEM method for invitations.


### PR DESCRIPTION
`invitations/INV/TOKEN` becomes `invitations/INV?token=TOKEN`

This fixes RBAC where the token was seen as a sub-resource.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
