### PR TITLE
Adjust logger log level to match debug level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ run-api: build ## Starts control api apiserver against the current Kubernetes cl
 .PHONY: run-controller
 run-controller: build ## Starts control api controller against the current Kubernetes cluster (based  on your local config)
 	$(localenv_make) webhook-certs/tls.key
-	$(BIN_FILENAME) controller --username-prefix "appuio#" --webhook-cert-dir=./local-env/webhook-certs --webhook-port=9444
+	$(BIN_FILENAME) controller --username-prefix "appuio#" --webhook-cert-dir=./local-env/webhook-certs --webhook-port=9444 --zap-log-level debug
 
 .PHONY: local-env
 local-env-setup: ## Setup local kind-based dev environment

--- a/apiserver/billing/odoostorage/odoo/odoo8/client/debug.go
+++ b/apiserver/billing/odoostorage/odoo/odoo8/client/debug.go
@@ -35,7 +35,7 @@ func (t *debugTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		defer reqBody.Close()
 		buf, _ := ioutil.ReadAll(reqBody)
 		buf = t.pwRe.ReplaceAll(buf, []byte(`$1[confidential]$2`))
-		logger.V(2).Info(fmt.Sprintf("%s %s ---> %s", r.Method, r.URL.Path, string(buf)))
+		logger.V(1).Info(fmt.Sprintf("%s %s ---> %s", r.Method, r.URL.Path, string(buf)))
 	}
 
 	res, err := http.DefaultTransport.RoundTrip(r)
@@ -46,7 +46,7 @@ func (t *debugTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if res.Body != nil {
 		defer res.Body.Close()
 		buf, _ := ioutil.ReadAll(res.Body)
-		logger.V(2).Info(fmt.Sprintf("%s %s <--- %s", r.Method, r.URL.Path, string(buf)))
+		logger.V(1).Info(fmt.Sprintf("%s %s <--- %s", r.Method, r.URL.Path, string(buf)))
 		res.Body = io.NopCloser(bytes.NewReader(buf))
 	}
 

--- a/controllers/invitation_cleanup_controller.go
+++ b/controllers/invitation_cleanup_controller.go
@@ -33,9 +33,9 @@ type InvitationCleanupReconciler struct {
 // Reconcile reacts on invitations and removes them if required
 func (r *InvitationCleanupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.V(4).WithValues("request", req).Info("Reconciling")
+	log.V(1).WithValues("request", req).Info("Reconciling")
 
-	log.V(4).Info("Getting the Invitation...")
+	log.V(1).Info("Getting the Invitation...")
 	inv := userv1.Invitation{}
 	if err := r.Get(ctx, req.NamespacedName, &inv); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -55,14 +55,14 @@ func (r *InvitationCleanupReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		cond := apimeta.FindStatusCondition(inv.Status.Conditions, userv1.ConditionRedeemed)
 		ttlExpirationTime := cond.LastTransitionTime.Add(r.RedeemedInvitationTTL)
 		if ttlExpirationTime.Before(now.Time) {
-			log.V(4).Info("Redeemed Invitation TTL expired - deleting", "ttlExpirationTime", ttlExpirationTime)
+			log.V(1).Info("Redeemed Invitation TTL expired - deleting", "ttlExpirationTime", ttlExpirationTime)
 			return ctrl.Result{}, r.Delete(ctx, &inv)
 		}
 		return ctrl.Result{RequeueAfter: ttlExpirationTime.Sub(now.Add(-time.Minute))}, nil
 	}
 
 	if inv.Status.ValidUntil.Before(&now) {
-		log.V(4).Info("Invitation expired - deleting")
+		log.V(1).Info("Invitation expired - deleting")
 		return ctrl.Result{}, r.Delete(ctx, &inv)
 	}
 

--- a/controllers/invitation_redeem_controller.go
+++ b/controllers/invitation_redeem_controller.go
@@ -35,7 +35,7 @@ type InvitationRedeemReconciler struct {
 // Reconcile reacts to redeemed invitations and adds the user to the targets listed in the invitation status.
 func (r *InvitationRedeemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.V(4).WithValues("request", req).Info("Reconciling")
+	log.V(1).WithValues("request", req).Info("Reconciling")
 
 	inv := userv1.Invitation{}
 	if err := r.Get(ctx, req.NamespacedName, &inv); err != nil {

--- a/controllers/invitation_token_controller.go
+++ b/controllers/invitation_token_controller.go
@@ -33,9 +33,9 @@ type InvitationTokenReconciler struct {
 // Reconcile reacts on invitations and adds a token to the status if required.
 func (r *InvitationTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.V(4).WithValues("request", req).Info("Reconciling")
+	log.V(1).WithValues("request", req).Info("Reconciling")
 
-	log.V(4).Info("Getting the User...")
+	log.V(1).Info("Getting the User...")
 	inv := userv1.Invitation{}
 	if err := r.Get(ctx, req.NamespacedName, &inv); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/controllers/org_billingentity_name_cache_controller.go
+++ b/controllers/org_billingentity_name_cache_controller.go
@@ -36,7 +36,7 @@ type OrgBillingEntityNameCacheController struct {
 // Reconcile periodically updates the organizations .status.billingEntityName field.
 func (r *OrgBillingEntityNameCacheController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.V(4).WithValues("request", req).Info("Reconciling")
+	log.V(1).WithValues("request", req).Info("Reconciling")
 
 	var org orgv1.Organization
 	if err := r.Get(ctx, req.NamespacedName, &org); err != nil {

--- a/controllers/organization_members_controller.go
+++ b/controllers/organization_members_controller.go
@@ -41,7 +41,7 @@ type OrganizationMembersReconciler struct {
 // Reconcile reacts on changes of users and mirrors these changes to Keycloak
 func (r *OrganizationMembersReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.V(4).WithValues("request", req).Info("Reconciling")
+	log.V(1).WithValues("request", req).Info("Reconciling")
 
 	memb := controlv1.OrganizationMembers{}
 	if err := r.Get(ctx, req.NamespacedName, &memb); err != nil {
@@ -88,7 +88,7 @@ func (r *OrganizationMembersReconciler) putRoleBinding(ctx context.Context, memb
 		}
 		return ctrl.SetControllerReference(&memb, &rb, r.Scheme)
 	})
-	log.FromContext(ctx).V(4).Info("reconcile RoleBinding", "operation", op)
+	log.FromContext(ctx).V(1).Info("reconcile RoleBinding", "operation", op)
 	return err
 }
 

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -35,9 +35,9 @@ type UserReconciler struct {
 // Reconcile reacts on changes of users and mirrors these changes to Keycloak
 func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.V(4).WithValues("request", req).Info("Reconciling")
+	log.V(1).WithValues("request", req).Info("Reconciling")
 
-	log.V(4).Info("Getting the User...")
+	log.V(1).Info("Getting the User...")
 	user := controlv1.User{}
 	if err := r.Get(ctx, req.NamespacedName, &user); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -47,7 +47,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	log.V(4).Info("Updating RBAC..")
+	log.V(1).Info("Updating RBAC..")
 	if err := r.setRBAC(ctx, user); err != nil {
 		r.Recorder.Event(&user, "Warning", "UpdateFailed", "Failed to set RBAC")
 		return ctrl.Result{}, err
@@ -81,7 +81,7 @@ func (r *UserReconciler) updateClusterRole(ctx context.Context, user controlv1.U
 		}
 		return ctrl.SetControllerReference(&user, &cr, r.Scheme)
 	})
-	log.FromContext(ctx).V(4).Info("reconcile ClusterRole", "operation", op)
+	log.FromContext(ctx).V(1).Info("reconcile ClusterRole", "operation", op)
 	return err
 }
 
@@ -106,7 +106,7 @@ func (r *UserReconciler) updateClusterRoleBinding(ctx context.Context, user cont
 		}
 		return ctrl.SetControllerReference(&user, &crb, r.Scheme)
 	})
-	log.FromContext(ctx).V(4).Info("reconcile ClusterRoleBinding", "operation", op)
+	log.FromContext(ctx).V(1).Info("reconcile ClusterRoleBinding", "operation", op)
 	return err
 }
 

--- a/webhooks/invitation_webhook.go
+++ b/webhooks/invitation_webhook.go
@@ -30,7 +30,7 @@ func (v *InvitationValidator) Handle(ctx context.Context, req admission.Request)
 	if err := v.decoder.Decode(req, inv); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	log.V(4).WithValues("invitation", inv).Info("Validating")
+	log.V(1).WithValues("invitation", inv).Info("Validating")
 
 	username := req.UserInfo.Username
 	authErrors := make([]error, 0, len(inv.Spec.TargetRefs))

--- a/webhooks/user_webhook.go
+++ b/webhooks/user_webhook.go
@@ -31,7 +31,7 @@ func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admis
 	if err := v.decoder.Decode(req, user); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	log.V(4).WithValues("user", user).Info("Validating")
+	log.V(1).WithValues("user", user).Info("Validating")
 
 	orgref := user.Spec.Preferences.DefaultOrganizationRef
 	if orgref == "" {
@@ -47,7 +47,7 @@ func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admis
 		return admission.Denied(fmt.Sprintf("Unable to load members for organization %s", orgref))
 	}
 
-	log.V(4).WithValues("orgref", orgref, "orgmemb", orgmemb).Info("organizationmembers of requested default organization")
+	log.V(1).WithValues("orgref", orgref, "orgmemb", orgmemb).Info("organizationmembers of requested default organization")
 
 	for _, orguser := range orgmemb.Spec.UserRefs {
 		if user.Name == orguser.Name {


### PR DESCRIPTION
## Summary

This sets all log statements to use log level 1, which corresponds to `debug` level.

Additionally, the makefile now starts the controller with debug log level, because I figured debug logs would be useful for local dev.
...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
