### PR TITLE
Fix basic users permission to redeem invitations

### DIFF
--- a/config/user-rbac/basic-user-role.yml
+++ b/config/user-rbac/basic-user-role.yml
@@ -27,4 +27,5 @@ rules:
   verbs: ["watch", "list", "redeem"]
 - apiGroups: ["user.appuio.io"]
   resources: ["invitations"]
-  verbs: ["get", "watch", "list", "redeem"]
+  # empty verb to allow upstream server to pass custom verbs to our aggregated API server
+  verbs: ["get", "watch", "list", "redeem", ""]


### PR DESCRIPTION
## Summary

Allow empty verb to allow upstream server to pass custom verbs to our aggregated API server. All permissions are double checked by the API server and our aggregate API server.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
