### PR TITLE
Reconcile even if no `EmailSent` condition can be found

### DIFF
--- a/controllers/invitation_email_controller.go
+++ b/controllers/invitation_email_controller.go
@@ -5,18 +5,24 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/multierr"
+	"golang.org/x/time/rate"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/appuio/control-api/mailsenders"
 
 	userv1 "github.com/appuio/control-api/apis/user/v1"
 )
+
+const ReasonSendFailed = "SendFailed"
 
 // InvitationEmailReconciler reconciles invitations and sends invitation emails if appropriate
 type InvitationEmailReconciler struct {
@@ -25,8 +31,8 @@ type InvitationEmailReconciler struct {
 	Recorder record.EventRecorder
 	Scheme   *runtime.Scheme
 
-	MailSender    mailsenders.MailSender
-	RetryInterval time.Duration
+	MailSender     mailsenders.MailSender
+	BaseRetryDelay time.Duration
 }
 
 //+kubebuilder:rbac:groups="rbac.appuio.io",resources=invitations,verbs=get;list;watch
@@ -48,35 +54,26 @@ func (r *InvitationEmailReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	if inv.Status.Token == "" {
+	if inv.Status.Token == "" || inv.Spec.Email == "" {
 		return ctrl.Result{}, nil
 	}
 
 	if apimeta.IsStatusConditionTrue(inv.Status.Conditions, userv1.ConditionEmailSent) {
 		return ctrl.Result{}, nil
 	}
-	condition := apimeta.FindStatusCondition(inv.Status.Conditions, userv1.ConditionEmailSent)
-
-	if condition == nil {
-		return ctrl.Result{}, nil
-	}
 
 	email := inv.Spec.Email
 	id, err := r.MailSender.Send(ctx, email, inv.Name, inv.Status.Token)
-
 	if err != nil {
 		log.V(0).Error(err, "Error in e-mail backend")
 
-		// Only update status if the error changes
-		if condition.Reason != err.Error() {
-			apimeta.SetStatusCondition(&inv.Status.Conditions, metav1.Condition{
-				Type:   userv1.ConditionEmailSent,
-				Status: metav1.ConditionFalse,
-				Reason: err.Error(),
-			})
-			return ctrl.Result{}, r.Client.Status().Update(ctx, &inv)
-		}
-		return ctrl.Result{RequeueAfter: r.RetryInterval}, nil
+		apimeta.SetStatusCondition(&inv.Status.Conditions, metav1.Condition{
+			Type:    userv1.ConditionEmailSent,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonSendFailed,
+			Message: err.Error(),
+		})
+		return ctrl.Result{}, multierr.Append(err, r.Client.Status().Update(ctx, &inv))
 	}
 
 	var message string
@@ -96,5 +93,17 @@ func (r *InvitationEmailReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *InvitationEmailReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&userv1.Invitation{}).
+		WithOptions(controller.Options{
+			RateLimiter: r.rateLimiter(),
+		}).
 		Complete(r)
+}
+
+func (r *InvitationEmailReconciler) rateLimiter() workqueue.RateLimiter {
+	// This is the default rate limiter for controllers with higher baseDelay if the reconciliation fails.
+	return workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(r.BaseRetryDelay, 5*time.Minute),
+		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
 }


### PR DESCRIPTION
- Use native error back-off functions.
- Fix (unused) event recorder name
- Implement Condition.Reason as expected by the API.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
