### PR TITLE
Render email body in controller

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -35,7 +35,7 @@ import (
 const (
 	defaultInvitationEmailTemplate = `Hi,
 
-You've been invited to join on a new group on APPUiO Cloud https://portal.dev/invitations/{{.Invitation.Metadata.Name}}?token={{.Invitation.Status.Token}}.
+You've been invited to join on a new group on APPUiO Cloud https://portal.dev/invitations/{{.Invitation.ObjectMeta.Name}}?token={{.Invitation.Status.Token}}.
 
 Best regards,
 APPUiO Cloud Team`
@@ -114,7 +114,10 @@ func ControllerCommand() *cobra.Command {
 			)
 			mailSender = &b
 		} else {
-			mailSender = &mailsenders.LogSender{Body: bodyRenderer}
+			mailSender = &mailsenders.StdoutSender{
+				Subject: *invEmailSubject,
+				Body:    bodyRenderer,
+			}
 		}
 
 		mgr, err := setupManager(

--- a/controllers/invitation_email_controller.go
+++ b/controllers/invitation_email_controller.go
@@ -63,7 +63,7 @@ func (r *InvitationEmailReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	email := inv.Spec.Email
-	id, err := r.MailSender.Send(ctx, email, inv.Name, inv.Status.Token)
+	id, err := r.MailSender.Send(ctx, email, inv)
 	if err != nil {
 		log.V(0).Error(err, "Error in e-mail backend")
 

--- a/controllers/invitation_email_controller_test.go
+++ b/controllers/invitation_email_controller_test.go
@@ -19,11 +19,11 @@ import (
 type FailingSender struct{}
 type SenderWithConstantId struct{}
 
-func (f *FailingSender) Send(context.Context, string, string, string) (string, error) {
+func (f *FailingSender) Send(context.Context, string, userv1.Invitation) (string, error) {
 	return "", errors.New("Err0r")
 }
 
-func (s *SenderWithConstantId) Send(context.Context, string, string, string) (string, error) {
+func (s *SenderWithConstantId) Send(context.Context, string, userv1.Invitation) (string, error) {
 	return "ID10", nil
 }
 

--- a/mailsenders/mail_senders.go
+++ b/mailsenders/mail_senders.go
@@ -2,9 +2,10 @@ package mailsenders
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/mailgun/mailgun-go/v4"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	userv1 "github.com/appuio/control-api/apis/user/v1"
 )
@@ -26,23 +27,22 @@ type MailgunSender struct {
 	Body *InvitationRenderer
 }
 
-var _ MailSender = &LogSender{}
+var _ MailSender = &StdoutSender{}
 
-// LogSender is a MailSender that logs the e-mail to stdout.
-type LogSender struct {
-	Body *InvitationRenderer
+// StdoutSender is a MailSender that logs the e-mail to stdout.
+type StdoutSender struct {
+	Subject string
+	Body    *InvitationRenderer
 }
 
-func (s *LogSender) Send(ctx context.Context, recipient string, inv userv1.Invitation) (string, error) {
-	log := log.FromContext(ctx)
-
+func (s *StdoutSender) Send(ctx context.Context, recipient string, inv userv1.Invitation) (string, error) {
 	body, err := s.Body.Render(inv)
 	if err != nil {
 		return "", err
 	}
 
-	log.V(0).Info("E-mail body", "body", body)
-	log.V(0).Info("E-mail backend is 'stdout'; invitation e-mail was not sent", "recipient", recipient)
+	border := strings.Repeat("=", 80)
+	fmt.Printf("\n%s\nRecipient: %s\nSubject: %s\n\n%s\n%s\n", border, recipient, s.Subject, body, border)
 
 	return "", nil
 }

--- a/mailsenders/renderer.go
+++ b/mailsenders/renderer.go
@@ -1,0 +1,26 @@
+package mailsenders
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+)
+
+type InvitationRenderer struct {
+	Template *template.Template
+}
+
+type templateData struct {
+	Invitation userv1.Invitation
+}
+
+func (ir InvitationRenderer) Render(inv userv1.Invitation) (string, error) {
+	body := &strings.Builder{}
+	err := ir.Template.Execute(body, templateData{Invitation: inv})
+	if err != nil {
+		return "", fmt.Errorf("failed to render e-mail body: %w", err)
+	}
+	return body.String(), nil
+}

--- a/mailsenders/renderer_test.go
+++ b/mailsenders/renderer_test.go
@@ -1,0 +1,28 @@
+package mailsenders_test
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/appuio/control-api/mailsenders"
+	"github.com/stretchr/testify/assert"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+)
+
+func Test_InvitationRenderer_Render(t *testing.T) {
+	tm, err := template.New("test").Parse("Hi {{.Invitation.Spec.Email}}, get your token: {{.Invitation.Status.Token}}")
+	assert.NoError(t, err)
+
+	subject := mailsenders.InvitationRenderer{Template: tm}
+	rendered, err := subject.Render(userv1.Invitation{
+		Spec: userv1.InvitationSpec{
+			Email: "test@example.com",
+		},
+		Status: userv1.InvitationStatus{
+			Token: "abc",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "Hi test@example.com, get your token: abc", rendered)
+}


### PR DESCRIPTION
## Summary

Renders email bodies inside the controller using Go templates because:
- Mailgun logs are broken with mailgun templates since [2019](https://feedback.mailgun.com/forums/156243-feature-requests/suggestions/38608327-fix-quick-view-for-templates).
- We might want to add SMTP at some point.
- We might need to pass additional data like links to the portal.
- We expect to only ever send plaintext emails anyways.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
