### PR TITLE
Invitation: Remove `appuio#` prefix from non RBAC objects

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -225,6 +225,8 @@ func setupManager(
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("invitation-redeem-controller"),
+
+		UsernamePrefix: usernamePrefix,
 	}
 	if err = invred.SetupWithManager(mgr); err != nil {
 		return nil, err
@@ -253,7 +255,9 @@ func setupManager(
 		Handler: &webhooks.UserValidator{},
 	})
 	mgr.GetWebhookServer().Register("/validate-user-appuio-io-v1-invitation", &webhook.Admission{
-		Handler: &webhooks.InvitationValidator{},
+		Handler: &webhooks.InvitationValidator{
+			UsernamePrefix: usernamePrefix,
+		},
 	})
 
 	//+kubebuilder:scaffold:builder

--- a/controllers/targetref/targetref_test.go
+++ b/controllers/targetref/targetref_test.go
@@ -75,13 +75,14 @@ func Test_GetTarget_UnsupportedType(t *testing.T) {
 }
 
 func Test_UserAccessor_AccessUser(t *testing.T) {
+	usernamePrefix := "appuio#"
 	tt := []client.Object{
 		&rbacv1.ClusterRoleBinding{
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:     rbacv1.UserKind,
 					APIGroup: rbacv1.GroupName,
-					Name:     "user1",
+					Name:     usernamePrefix + "user1",
 				},
 			},
 		},
@@ -90,7 +91,7 @@ func Test_UserAccessor_AccessUser(t *testing.T) {
 				{
 					Kind:     rbacv1.UserKind,
 					APIGroup: rbacv1.GroupName,
-					Name:     "user1",
+					Name:     usernamePrefix + "user1",
 				},
 			},
 		},
@@ -115,11 +116,11 @@ func Test_UserAccessor_AccessUser(t *testing.T) {
 			a, err := targetref.NewUserAccessor(obj)
 			require.NoError(t, err)
 
-			require.False(t, a.HasUser("user2"))
-			require.True(t, a.EnsureUser("user2"))
-			require.True(t, a.HasUser("user2"))
-			require.False(t, a.EnsureUser("user2"))
-			require.True(t, a.HasUser("user2"))
+			require.False(t, a.HasUser(usernamePrefix, "user2"))
+			require.True(t, a.EnsureUser(usernamePrefix, "user2"))
+			require.True(t, a.HasUser(usernamePrefix, "user2"))
+			require.False(t, a.EnsureUser(usernamePrefix, "user2"))
+			require.True(t, a.HasUser(usernamePrefix, "user2"))
 		})
 	}
 }

--- a/webhooks/invitation_webhook.go
+++ b/webhooks/invitation_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"go.uber.org/multierr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +21,8 @@ import (
 type InvitationValidator struct {
 	client  client.Client
 	decoder *admission.Decoder
+
+	UsernamePrefix string
 }
 
 // Handle handles the users.appuio.io admission requests
@@ -33,9 +36,14 @@ func (v *InvitationValidator) Handle(ctx context.Context, req admission.Request)
 	log.V(1).WithValues("invitation", inv).Info("Validating")
 
 	username := req.UserInfo.Username
+	if !strings.HasPrefix(username, v.UsernamePrefix) {
+		return admission.Denied(fmt.Sprintf("no username prefix expected prefix %q, current user %q", v.UsernamePrefix, username))
+	}
+	username = strings.TrimPrefix(username, v.UsernamePrefix)
+
 	authErrors := make([]error, 0, len(inv.Spec.TargetRefs))
 	for _, target := range inv.Spec.TargetRefs {
-		authErrors = append(authErrors, authorizeTarget(ctx, v.client, username, target))
+		authErrors = append(authErrors, authorizeTarget(ctx, v.client, username, v.UsernamePrefix, target))
 	}
 	if err := multierr.Combine(authErrors...); err != nil {
 		return admission.Denied(fmt.Sprintf("user %q is not allowed to invite to the targets: %s", username, err))
@@ -56,7 +64,7 @@ func (v *InvitationValidator) InjectClient(c client.Client) error {
 	return nil
 }
 
-func authorizeTarget(ctx context.Context, c client.Client, user string, target userv1.TargetRef) error {
+func authorizeTarget(ctx context.Context, c client.Client, user, prefix string, target userv1.TargetRef) error {
 	o, err := targetref.GetTarget(ctx, c, target)
 	if err != nil {
 		return err
@@ -67,7 +75,7 @@ func authorizeTarget(ctx context.Context, c client.Client, user string, target u
 		return err
 	}
 
-	if a.HasUser(user) {
+	if a.HasUser(prefix, user) {
 		return nil
 	}
 

--- a/webhooks/invitation_webhook.go
+++ b/webhooks/invitation_webhook.go
@@ -37,7 +37,7 @@ func (v *InvitationValidator) Handle(ctx context.Context, req admission.Request)
 
 	username := req.UserInfo.Username
 	if !strings.HasPrefix(username, v.UsernamePrefix) {
-		return admission.Denied(fmt.Sprintf("no username prefix expected prefix %q, current user %q", v.UsernamePrefix, username))
+		return admission.Denied(fmt.Sprintf("Invalid username: only usernames with prefix %q are accepted, got username %q", v.UsernamePrefix, username))
 	}
 	username = strings.TrimPrefix(username, v.UsernamePrefix)
 


### PR DESCRIPTION
## Summary

We use the prefix only for RBAC objects. Everything in our own API-Server is non-prefixed 🤷‍♀️

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
