### PR TITLE
Add metrics that indicate the status of email sending

### DIFF
--- a/controllers/invitation_email_controller.go
+++ b/controllers/invitation_email_controller.go
@@ -41,16 +41,16 @@ type InvitationEmailReconciler struct {
 
 func NewSuccessCounter() prometheus.Counter {
 	return prometheus.NewCounter(prometheus.CounterOpts{
-		Subsystem: "control_api",
-		Name:      "emails_sent_success_total",
+		Subsystem: "control_api_invitation_emails",
+		Name:      "sent_success_total",
 		Help:      "Total number of successfully sent invitation e-mails",
 	})
 }
 
 func NewFailureCounter() prometheus.Counter {
 	return prometheus.NewCounter(prometheus.CounterOpts{
-		Subsystem: "control_api",
-		Name:      "emails_sent_failed_total",
+		Subsystem: "control_api_invitation_emails",
+		Name:      "sent_failed_total",
 		Help:      "Total number of invitation e-mails which failed to send",
 	})
 }

--- a/controllers/invitation_email_controller.go
+++ b/controllers/invitation_email_controller.go
@@ -35,11 +35,24 @@ type InvitationEmailReconciler struct {
 	MailSender     mailsenders.MailSender
 	BaseRetryDelay time.Duration
 
-	FailureCounter prometheus.Counter
-	SuccessCounter prometheus.Counter
+	failureCounter prometheus.Counter
+	successCounter prometheus.Counter
 }
 
-func NewSuccessCounter() prometheus.Counter {
+func NewInvitationEmailReconciler(client client.Client, eventRecorder record.EventRecorder, scheme *runtime.Scheme, mailSender mailsenders.MailSender, baseRetryDelay time.Duration) InvitationEmailReconciler {
+	return InvitationEmailReconciler{
+		Client:         client,
+		Recorder:       eventRecorder,
+		Scheme:         scheme,
+		MailSender:     mailSender,
+		BaseRetryDelay: baseRetryDelay,
+		failureCounter: newFailureCounter(),
+		successCounter: newSuccessCounter(),
+	}
+
+}
+
+func newSuccessCounter() prometheus.Counter {
 	return prometheus.NewCounter(prometheus.CounterOpts{
 		Subsystem: "control_api_invitation_emails",
 		Name:      "sent_success_total",
@@ -47,12 +60,19 @@ func NewSuccessCounter() prometheus.Counter {
 	})
 }
 
-func NewFailureCounter() prometheus.Counter {
+func newFailureCounter() prometheus.Counter {
 	return prometheus.NewCounter(prometheus.CounterOpts{
 		Subsystem: "control_api_invitation_emails",
 		Name:      "sent_failed_total",
 		Help:      "Total number of invitation e-mails which failed to send",
 	})
+}
+
+func (r *InvitationEmailReconciler) GetMetrics() prometheus.Collector {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(r.failureCounter)
+	reg.MustRegister(r.successCounter)
+	return reg
 }
 
 //+kubebuilder:rbac:groups="rbac.appuio.io",resources=invitations,verbs=get;list;watch
@@ -86,7 +106,7 @@ func (r *InvitationEmailReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	id, err := r.MailSender.Send(ctx, email, inv)
 	if err != nil {
 		log.V(0).Error(err, "Error in e-mail backend")
-		r.FailureCounter.Add(1)
+		r.failureCounter.Add(1)
 		apimeta.SetStatusCondition(&inv.Status.Conditions, metav1.Condition{
 			Type:    userv1.ConditionEmailSent,
 			Status:  metav1.ConditionFalse,
@@ -95,7 +115,7 @@ func (r *InvitationEmailReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		})
 		return ctrl.Result{}, multierr.Append(err, r.Client.Status().Update(ctx, &inv))
 	}
-	r.SuccessCounter.Add(1)
+	r.successCounter.Add(1)
 
 	var message string
 	if id != "" {

--- a/controllers/invitation_email_controller_test.go
+++ b/controllers/invitation_email_controller_test.go
@@ -93,12 +93,12 @@ func Test_InvitationEmailReconciler_Reconcile_MetricsCorrect(t *testing.T) {
 	reg.MustRegister(r.FailureCounter)
 	reg.MustRegister(r.SuccessCounter)
 	require.NoError(t, testutil.CollectAndCompare(reg, strings.NewReader(`
-# HELP control_api_emails_sent_failed_total Total number of invitation e-mails which failed to send
-# TYPE control_api_emails_sent_failed_total counter
-control_api_emails_sent_failed_total 0
-# HELP control_api_emails_sent_success_total Total number of successfully sent invitation e-mails
-# TYPE control_api_emails_sent_success_total counter
-control_api_emails_sent_success_total 1
+# HELP control_api_invitation_emails_sent_failed_total Total number of invitation e-mails which failed to send
+# TYPE control_api_invitation_emails_sent_failed_total counter
+control_api_invitation_emails_sent_failed_total 0
+# HELP control_api_invitation_emails_sent_success_total Total number of successfully sent invitation e-mails
+# TYPE control_api_invitation_emails_sent_success_total counter
+control_api_invitation_emails_sent_success_total 1
 `),
 	))
 }
@@ -122,12 +122,12 @@ func Test_InvitationEmailReconciler_Reconcile_WithSendingFailure_MetricsCorrect(
 	reg.MustRegister(r.FailureCounter)
 	reg.MustRegister(r.SuccessCounter)
 	require.NoError(t, testutil.CollectAndCompare(reg, strings.NewReader(`
-# HELP control_api_emails_sent_failed_total Total number of invitation e-mails which failed to send
-# TYPE control_api_emails_sent_failed_total counter
-control_api_emails_sent_failed_total 1
-# HELP control_api_emails_sent_success_total Total number of successfully sent invitation e-mails
-# TYPE control_api_emails_sent_success_total counter
-control_api_emails_sent_success_total 0
+# HELP control_api_invitation_emails_sent_failed_total Total number of invitation e-mails which failed to send
+# TYPE control_api_invitation_emails_sent_failed_total counter
+control_api_invitation_emails_sent_failed_total 1
+# HELP control_api_invitation_emails_sent_success_total Total number of successfully sent invitation e-mails
+# TYPE control_api_invitation_emails_sent_success_total counter
+control_api_invitation_emails_sent_success_total 0
 `),
 	))
 }

--- a/controllers/invitation_email_pending_metric.go
+++ b/controllers/invitation_email_pending_metric.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+)
+
+//+kubebuilder:rbac:groups="rbac.appuio.io",resources=organizations,verbs=get;list;watch
+//+kubebuilder:rbac:groups="organization.appuio.io",resources=organizations,verbs=get;list;watch
+
+var emailPendingDesc = prometheus.NewDesc(
+	"control_api_email_pending_current",
+	"Amount of e-mails that have not been sent yet",
+	nil,
+	nil,
+)
+
+// OrgBillingRefLinkMetric is a Prometheus collector that exposes the link between an organization and a billing entity.
+type EmailPendingMetric struct {
+	client.Client
+}
+
+var _ prometheus.Collector = &EmailPendingMetric{}
+
+// Describe implements prometheus.Collector.
+// Sends the static description of the metric to the provided channel.
+func (e *EmailPendingMetric) Describe(ch chan<- *prometheus.Desc) {
+	ch <- emailPendingDesc
+}
+
+// Collect implements prometheus.Collector.
+// Sends a metric for each organization and its billing entity to the provided channel.
+func (e *EmailPendingMetric) Collect(ch chan<- prometheus.Metric) {
+	invs := &userv1.InvitationList{}
+
+	if err := e.List(context.Background(), invs); err != nil {
+		ch <- prometheus.NewInvalidMetric(emailPendingDesc, err)
+		return
+	}
+
+	var count float64 = 0
+	for _, inv := range invs.Items {
+		if !apimeta.IsStatusConditionTrue(inv.Status.Conditions, userv1.ConditionEmailSent) {
+			count++
+		}
+	}
+	ch <- prometheus.MustNewConstMetric(
+		emailPendingDesc,
+		prometheus.GaugeValue,
+		count,
+	)
+}

--- a/controllers/invitation_email_pending_metric.go
+++ b/controllers/invitation_email_pending_metric.go
@@ -14,7 +14,7 @@ import (
 //+kubebuilder:rbac:groups="organization.appuio.io",resources=organizations,verbs=get;list;watch
 
 var emailPendingDesc = prometheus.NewDesc(
-	"control_api_email_pending_current",
+	"control_api_invitation_emails_pending_current",
 	"Amount of e-mails that have not been sent yet",
 	nil,
 	nil,

--- a/controllers/invitation_email_pending_metric.go
+++ b/controllers/invitation_email_pending_metric.go
@@ -10,8 +10,10 @@ import (
 	userv1 "github.com/appuio/control-api/apis/user/v1"
 )
 
-//+kubebuilder:rbac:groups="rbac.appuio.io",resources=organizations,verbs=get;list;watch
-//+kubebuilder:rbac:groups="organization.appuio.io",resources=organizations,verbs=get;list;watch
+//+kubebuilder:rbac:groups="rbac.appuio.io",resources=invitations,verbs=get;list;watch
+//+kubebuilder:rbac:groups="user.appuio.io",resources=invitations,verbs=get;list;watch
+//+kubebuilder:rbac:groups="rbac.appuio.io",resources=invitations/status,verbs=get
+//+kubebuilder:rbac:groups="user.appuio.io",resources=invitations/status,verbs=get
 
 var emailPendingDesc = prometheus.NewDesc(
 	"control_api_invitation_emails_pending_current",
@@ -20,7 +22,7 @@ var emailPendingDesc = prometheus.NewDesc(
 	nil,
 )
 
-// OrgBillingRefLinkMetric is a Prometheus collector that exposes the link between an organization and a billing entity.
+// EmailPendingMetric is a Prometheus collector that exposes the number of currently pending invitation e-mails
 type EmailPendingMetric struct {
 	client.Client
 }
@@ -34,7 +36,7 @@ func (e *EmailPendingMetric) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect implements prometheus.Collector.
-// Sends a metric for each organization and its billing entity to the provided channel.
+// Sends a metric to the provided channel.
 func (e *EmailPendingMetric) Collect(ch chan<- prometheus.Metric) {
 	invs := &userv1.InvitationList{}
 

--- a/controllers/invitation_email_pending_metric_test.go
+++ b/controllers/invitation_email_pending_metric_test.go
@@ -28,9 +28,9 @@ func TestEmailPendingMetric(t *testing.T) {
 
 	require.NoError(t,
 		testutil.CollectAndCompare(&controllers.EmailPendingMetric{c}, strings.NewReader(`
-# HELP control_api_email_pending_current Amount of e-mails that have not been sent yet
-# TYPE control_api_email_pending_current gauge
-control_api_email_pending_current 1
+# HELP control_api_invitation_emails_pending_current Amount of e-mails that have not been sent yet
+# TYPE control_api_invitation_emails_pending_current gauge
+control_api_invitation_emails_pending_current 1
 `),
 		),
 	)

--- a/controllers/invitation_email_pending_metric_test.go
+++ b/controllers/invitation_email_pending_metric_test.go
@@ -1,0 +1,37 @@
+package controllers_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	userv1 "github.com/appuio/control-api/apis/user/v1"
+	"github.com/appuio/control-api/controllers"
+)
+
+func TestEmailPendingMetric(t *testing.T) {
+	c := prepareTest(t, &userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-inv",
+		},
+		Spec:   userv1.InvitationSpec{},
+		Status: userv1.InvitationStatus{Conditions: []metav1.Condition{{Type: userv1.ConditionEmailSent, Status: metav1.ConditionTrue}}},
+	}, &userv1.Invitation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-inv-2",
+		},
+		Spec: userv1.InvitationSpec{},
+	})
+
+	require.NoError(t,
+		testutil.CollectAndCompare(&controllers.EmailPendingMetric{c}, strings.NewReader(`
+# HELP control_api_email_pending_current Amount of e-mails that have not been sent yet
+# TYPE control_api_email_pending_current gauge
+control_api_email_pending_current 1
+`),
+		),
+	)
+}


### PR DESCRIPTION
## Summary

Adds the following new metrics to the controller:

```
 HELP control_api_invitation_emails_pending_current Amount of e-mails that have not been sent yet
# TYPE control_api_invitation_emails_pending_current gauge
control_api_invitation_emails_pending_current 0
# HELP control_api_invitation_emails_sent_failed_total Total number of invitation e-mails which failed to send
# TYPE control_api_invitation_emails_sent_failed_total counter
control_api_invitation_emails_sent_failed_total 0
# HELP control_api_invitation_emails_sent_success_total Total number of successfully sent invitation e-mails
# TYPE control_api_invitation_emails_sent_success_total counter
control_api_invitation_emails_sent_success_total 0
```

These metrics allow to observe and alert on the status of invitation e-mail sending.
...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
