### PR TITLE
Allow kubectl to validate CRDs client side

### DIFF
--- a/config/user-rbac/basic-user-role.yml
+++ b/config/user-rbac/basic-user-role.yml
@@ -3,6 +3,11 @@ kind: ClusterRole
 metadata:
   name: control-api:basic-user
 rules:
+# Allow kubectl to validate CRDs
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "watch", "list"]
+
 - apiGroups: ["organization.appuio.io"]
   resources: ["organizations"]
   verbs: ["get", "watch", "list", "patch", "update", "create"]


### PR DESCRIPTION
Otherwise `kubectl` shows permission error without passing `--validate=false` for basic users.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
