### PR TITLE
Fix service account kubebuilder annotations

### DIFF
--- a/config/rbac/controller/role.yaml
+++ b/config/rbac/controller/role.yaml
@@ -86,7 +86,17 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - billing.appuio.io
+  resources:
+  - billingentities/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - organization.appuio.io
   resources:
@@ -114,6 +124,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.appuio.io
@@ -197,21 +209,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - user.appuio.io
-  resources:
-  - billingentities
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - user.appuio.io
-  resources:
-  - billingentities/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - user.appuio.io
   resources:

--- a/controllers/billingentity_email_cronjob.go
+++ b/controllers/billingentity_email_cronjob.go
@@ -52,10 +52,10 @@ func (r *BillingEntityEmailCronJob) GetMetrics() prometheus.Collector {
 	return reg
 }
 
-//+kubebuilder:rbac:groups="rbac.appuio.io",resources=billingentities,verbs=get;list
-//+kubebuilder:rbac:groups="user.appuio.io",resources=billingentities,verbs=get;list
+//+kubebuilder:rbac:groups="rbac.appuio.io",resources=billingentities,verbs=get;list;update;patch
+//+kubebuilder:rbac:groups="billing.appuio.io",resources=billingentities,verbs=get;list;update;patch
 //+kubebuilder:rbac:groups="rbac.appuio.io",resources=billingentities/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="user.appuio.io",resources=billingentities/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups="billing.appuio.io",resources=billingentities/status,verbs=get;update;patch
 
 // Run lists all BillingEntity resources and sends notification emails if needed.
 func (r *BillingEntityEmailCronJob) Run(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Due to copy-paste error, the annotations were giving the wrong permissions, causing things to not work.
...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
