### PR TITLE
Allow users to create their own settings

### DIFF
--- a/config/user-rbac/basic-user-role.yml
+++ b/config/user-rbac/basic-user-role.yml
@@ -40,3 +40,7 @@ rules:
 - apiGroups: ["user.appuio.io"]
   resources: ["invitationredeemrequests"]
   verbs: ["create"]
+# Allow users to create themselves, user create requests are validated by the users validation webhook
+- apiGroups: ["appuio.io"]
+  resources: ["users"]
+  verbs: ["create"]

--- a/pkg/sar/resource_attributes.go
+++ b/pkg/sar/resource_attributes.go
@@ -1,0 +1,31 @@
+package sar
+
+// ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface.
+// From https://github.com/kubernetes/api/blob/2f9553831ec24dc60e3e1c3a374fb63ca091688f/authorization/v1/types.go#L92-L118.
+// Importing the whole package confuses go mod.
+type ResourceAttributes struct {
+	// Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces
+	// "" (empty) is defaulted for LocalSubjectAccessReviews
+	// "" (empty) is empty for cluster-scoped resources
+	// "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
+	// +optional
+	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
+	// Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+	// +optional
+	Verb string `json:"verb,omitempty" protobuf:"bytes,2,opt,name=verb"`
+	// Group is the API Group of the Resource.  "*" means all.
+	// +optional
+	Group string `json:"group,omitempty" protobuf:"bytes,3,opt,name=group"`
+	// Version is the API Version of the Resource.  "*" means all.
+	// +optional
+	Version string `json:"version,omitempty" protobuf:"bytes,4,opt,name=version"`
+	// Resource is one of the existing resource types.  "*" means all.
+	// +optional
+	Resource string `json:"resource,omitempty" protobuf:"bytes,5,opt,name=resource"`
+	// Subresource is one of the existing resource types.  "" means none.
+	// +optional
+	Subresource string `json:"subresource,omitempty" protobuf:"bytes,6,opt,name=subresource"`
+	// Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
+	// +optional
+	Name string `json:"name,omitempty" protobuf:"bytes,7,opt,name=name"`
+}

--- a/pkg/sar/sar.go
+++ b/pkg/sar/sar.go
@@ -1,0 +1,85 @@
+package sar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AuthorizeResource checks if the given user is allowed to access the given resource, using SubjectAccessReviews.
+func AuthorizeResource(ctx context.Context, c client.Client, user authenticationv1.UserInfo, resource ResourceAttributes) error {
+	// I could not find a way to create a SubjectAccessReview object with the client.
+	// `no kind "CreateOptions" is registered for the internal version of group "authorization.k8s.io" in scheme`
+	// even after installing the authorization scheme.
+	rawSAR := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": sarSpec{
+				ResourceAttributes: resource,
+
+				User:   user.Username,
+				Groups: user.Groups,
+				Extra:  user.Extra,
+				UID:    user.UID,
+			},
+		}}
+	rawSAR.SetGroupVersionKind(schema.GroupVersionKind{Group: "authorization.k8s.io", Version: "v1", Kind: "SubjectAccessReview"})
+
+	if err := c.Create(ctx, rawSAR); err != nil {
+		return fmt.Errorf("failed to create SubjectAccessReview: %w", err)
+	}
+
+	allowed, _, err := unstructured.NestedBool(rawSAR.Object, "status", "allowed")
+	if err != nil {
+		return fmt.Errorf("failed to get SubjectAccessReview status.allowed: %w", err)
+	}
+
+	if !allowed {
+		return fmt.Errorf("%q is not allowed by %q", resource, user)
+	}
+
+	return nil
+}
+
+// MOCK_SubjectAccessReviewResponder is a wrapper for client.WithWatch that responds to SubjectAccessReview create requests
+// and allows or denies the request based on the AllowedUser name.
+type MOCK_SubjectAccessReviewResponder struct {
+	client.WithWatch
+
+	AllowedUser string
+}
+
+func (r MOCK_SubjectAccessReviewResponder) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if sar, ok := obj.(*unstructured.Unstructured); ok {
+		if sar.GetKind() == "SubjectAccessReview" {
+			o, ok, err := unstructured.NestedFieldNoCopy(sar.Object, "spec")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return errors.New("spec not found")
+			}
+			s, ok := o.(sarSpec)
+			if !ok {
+				return errors.New("unknown spec type, might not originate from this package")
+			}
+
+			unstructured.SetNestedField(sar.Object, s.User == r.AllowedUser, "status", "allowed")
+			return nil
+		}
+	}
+	return r.WithWatch.Create(ctx, obj, opts...)
+}
+
+type sarSpec struct {
+	ResourceAttributes ResourceAttributes `json:"resourceAttributes"`
+
+	User   string                                 `json:"user,omitempty"`
+	Groups []string                               `json:"groups,omitempty"`
+	Extra  map[string]authenticationv1.ExtraValue `json:"extra,omitempty"`
+	UID    string                                 `json:"uid,omitempty"`
+}


### PR DESCRIPTION
## Summary

Allows users to create their own settings by validating the name of the created settings. This allows users to set settings before they are reconciled from the external IDP.

Having a special permission `create rbac.appuio.io/users` allows overriding the validation for controllers creating users.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
