### PR TITLE
UserValidator: Fix wrong `Resource` parameter in override validation SAR

### DIFF
--- a/webhooks/user_webhook.go
+++ b/webhooks/user_webhook.go
@@ -35,10 +35,11 @@ func (v *UserValidator) Handle(ctx context.Context, req admission.Request) admis
 		if err := sar.AuthorizeResource(ctx, v.client, req.UserInfo, sar.ResourceAttributes{
 			Verb:     "create",
 			Group:    "rbac.appuio.io",
-			Resource: req.Resource.Group,
+			Resource: req.Resource.Resource,
 			Version:  req.Resource.Version,
 			Name:     req.Name,
 		}); err != nil {
+			log.Info("User not authorized to create other users", "request_user", req.AdmissionRequest.UserInfo, "user", req.Name, "error", err)
 			return admission.Denied(fmt.Sprintf("user %q is not allowed to create or update %q", req.UserInfo.Username, req.Name))
 		}
 		log.Info("User authorized to create other users", "user", req.AdmissionRequest.UserInfo)


### PR DESCRIPTION
## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
