### PR TITLE
Update Keycloak Realm template for local environment setup

### DIFF
--- a/local-env/templates/realm.json.tpl
+++ b/local-env/templates/realm.json.tpl
@@ -1014,6 +1014,21 @@
           "config": {}
         },
         {
+          "name": "client-role-groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String",
+            "usermodel.clientRoleMapping.clientId": "local-dev"
+          }
+        },
+        {
           "name": "client roles",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-client-role-mapper",


### PR DESCRIPTION
Recent Keycloak versions don't support custom mappers in individual clients anymore.

To work around this issue, we instead patch the default `roles` client scope to include the `local-dev` client roles in the `groups` field of the ID and access tokens.


## Summary

...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
