### PR TITLE
Fix naming of `salesOrder` properties in status subresource

### DIFF
--- a/apis/organization/v1/organization_types.go
+++ b/apis/organization/v1/organization_types.go
@@ -35,10 +35,10 @@ var (
 	BillingEntityRefKey = "organization.appuio.io/billing-entity-ref"
 	// BillingEntityNameKey is the annotation key that stores the billing entity name
 	BillingEntityNameKey = "status.organization.appuio.io/billing-entity-name"
-	// SaleOrderIdKey is the annotation key that stores the sale order ID
-	SaleOrderIdKey = "status.organization.appuio.io/sale-order-id"
-	// SaleOrderNameKey is the annotation key that stores the sale order name
-	SaleOrderNameKey = "status.organization.appuio.io/sale-order-name"
+	// SalesOrderIdKey is the annotation key that stores the sale order ID
+	SalesOrderIdKey = "status.organization.appuio.io/sales-order-id"
+	// SalesOrderNameKey is the annotation key that stores the sale order name
+	SalesOrderNameKey = "status.organization.appuio.io/sales-order-name"
 	// StatusConditionsKey is the annotation key that stores the serialized status conditions
 	StatusConditionsKey = "status.organization.appuio.io/conditions"
 )
@@ -55,8 +55,8 @@ func NewOrganizationFromNS(ns *corev1.Namespace) *Organization {
 		billingEntityRef = ns.Annotations[BillingEntityRefKey]
 		billingEntityName = ns.Annotations[BillingEntityNameKey]
 		statusConditionsString = ns.Annotations[StatusConditionsKey]
-		saleOrderId = ns.Annotations[SaleOrderIdKey]
-		saleOrderName = ns.Annotations[SaleOrderNameKey]
+		saleOrderId = ns.Annotations[SalesOrderIdKey]
+		saleOrderName = ns.Annotations[SalesOrderNameKey]
 	}
 	var conditions []metav1.Condition
 	err := json.Unmarshal([]byte(statusConditionsString), &conditions)
@@ -71,8 +71,8 @@ func NewOrganizationFromNS(ns *corev1.Namespace) *Organization {
 		},
 		Status: OrganizationStatus{
 			BillingEntityName: billingEntityName,
-			SaleOrderID:       saleOrderId,
-			SaleOrderName:     saleOrderName,
+			SalesOrderID:      saleOrderId,
+			SalesOrderName:    saleOrderName,
 			Conditions:        conditions,
 		},
 	}
@@ -111,11 +111,11 @@ type OrganizationStatus struct {
 	// BillingEntityName is the name of the billing entity
 	BillingEntityName string `json:"billingEntityName,omitempty"`
 
-	// SaleOrderID is the ID of the sale order
-	SaleOrderID string `json:"saleOrderId,omitempty"`
+	// SalesOrderID is the ID of the sale order
+	SalesOrderID string `json:"salesOrderId,omitempty"`
 
-	// SaleOrderName is the name of the sale order
-	SaleOrderName string `json:"saleOrderName,omitempty"`
+	// SalesOrderName is the name of the sale order
+	SalesOrderName string `json:"salesOrderName,omitempty"`
 
 	// Conditions is a list of conditions for the invitation
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -201,11 +201,11 @@ func (o *Organization) ToNamespace() *corev1.Namespace {
 	ns.Annotations[DisplayNameKey] = o.Spec.DisplayName
 	ns.Annotations[BillingEntityRefKey] = o.Spec.BillingEntityRef
 	ns.Annotations[BillingEntityNameKey] = o.Status.BillingEntityName
-	if o.Status.SaleOrderID != "" {
-		ns.Annotations[SaleOrderIdKey] = o.Status.SaleOrderID
+	if o.Status.SalesOrderID != "" {
+		ns.Annotations[SalesOrderIdKey] = o.Status.SalesOrderID
 	}
-	if o.Status.SaleOrderName != "" {
-		ns.Annotations[SaleOrderNameKey] = o.Status.SaleOrderName
+	if o.Status.SalesOrderName != "" {
+		ns.Annotations[SalesOrderNameKey] = o.Status.SalesOrderName
 	}
 	if statusString != "" {
 		ns.Annotations[StatusConditionsKey] = statusString

--- a/controllers/org_info_metric.go
+++ b/controllers/org_info_metric.go
@@ -47,7 +47,7 @@ func (o *OrgInfoMetric) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			1,
 			org.Name,
-			org.Status.SaleOrderName,
+			org.Status.SalesOrderName,
 		)
 	}
 }

--- a/controllers/org_info_metric_test.go
+++ b/controllers/org_info_metric_test.go
@@ -35,7 +35,7 @@ func TestOrgInfoMetric(t *testing.T) {
 			BillingEntityRef: "be-234",
 		},
 		Status: orgv1.OrganizationStatus{
-			SaleOrderName: "SO9999",
+			SalesOrderName: "SO9999",
 		},
 	})
 

--- a/controllers/sale_order_controller.go
+++ b/controllers/sale_order_controller.go
@@ -46,11 +46,11 @@ func (r *SaleOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
-	if org.Status.SaleOrderName != "" {
+	if org.Status.SalesOrderName != "" {
 		return ctrl.Result{}, nil
 	}
 
-	if org.Status.SaleOrderID != "" {
+	if org.Status.SalesOrderID != "" {
 		// ID is present, but Name is not. Update name.
 		soName, err := r.SaleOrderStorage.GetSaleOrderName(org)
 		if err != nil {
@@ -67,7 +67,7 @@ func (r *SaleOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			Type:   organizationv1.ConditionSaleOrderNameUpdated,
 			Status: metav1.ConditionTrue,
 		})
-		org.Status.SaleOrderName = soName
+		org.Status.SalesOrderName = soName
 		return ctrl.Result{}, r.Client.Status().Update(ctx, &org)
 	}
 
@@ -90,7 +90,7 @@ func (r *SaleOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Status: metav1.ConditionTrue,
 	})
 
-	org.Status.SaleOrderID = fmt.Sprint(soId)
+	org.Status.SalesOrderID = fmt.Sprint(soId)
 	return ctrl.Result{}, r.Client.Status().Update(ctx, &org)
 }
 

--- a/controllers/sale_order_controller_test.go
+++ b/controllers/sale_order_controller_test.go
@@ -50,7 +50,7 @@ func Test_SaleOrderReconciler_Reconcile_Create_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject))
-	require.Equal(t, "123", subject.Status.SaleOrderID)
+	require.Equal(t, "123", subject.Status.SalesOrderID)
 	cond := apimeta.FindStatusCondition(subject.Status.Conditions, organizationv1.ConditionSaleOrderCreated)
 	require.Equal(t, metav1.ConditionTrue, cond.Status)
 }
@@ -68,7 +68,7 @@ func Test_SaleOrderReconciler_Reconcile_UpdateName_Success(t *testing.T) {
 			BillingEntityRef: "be-0000",
 		},
 		Status: organizationv1.OrganizationStatus{
-			SaleOrderID: "123",
+			SalesOrderID: "123",
 		},
 	}
 	c := prepareTest(t, &subject)
@@ -90,8 +90,8 @@ func Test_SaleOrderReconciler_Reconcile_UpdateName_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: subject.Name}, &subject))
-	require.Equal(t, "123", subject.Status.SaleOrderID)
-	require.Equal(t, "SO123", subject.Status.SaleOrderName)
+	require.Equal(t, "123", subject.Status.SalesOrderID)
+	require.Equal(t, "SO123", subject.Status.SalesOrderName)
 	cond := apimeta.FindStatusCondition(subject.Status.Conditions, organizationv1.ConditionSaleOrderNameUpdated)
 	require.Equal(t, metav1.ConditionTrue, cond.Status)
 }
@@ -109,8 +109,8 @@ func Test_SaleOrderReconciler_Reconcile_NoAction_Success(t *testing.T) {
 			BillingEntityRef: "be-0000",
 		},
 		Status: organizationv1.OrganizationStatus{
-			SaleOrderID:   "123",
-			SaleOrderName: "SO123",
+			SalesOrderID:   "123",
+			SalesOrderName: "SO123",
 		},
 	}
 	c := prepareTest(t, &subject)
@@ -268,8 +268,8 @@ func Test_SaleOrderReconciler_Create_StatusConditionCleared(t *testing.T) {
 	cond = apimeta.FindStatusCondition(subject.Status.Conditions, organizationv1.ConditionSaleOrderNameUpdated)
 	require.Equal(t, metav1.ConditionTrue, cond.Status)
 	require.Equal(t, "", cond.Reason)
-	require.Equal(t, "456", subject.Status.SaleOrderID)
-	require.Equal(t, "ST456", subject.Status.SaleOrderName)
+	require.Equal(t, "456", subject.Status.SalesOrderID)
+	require.Equal(t, "ST456", subject.Status.SalesOrderName)
 }
 
 func Test_SaleOrderReconciler_UpdateName_Error(t *testing.T) {
@@ -285,7 +285,7 @@ func Test_SaleOrderReconciler_UpdateName_Error(t *testing.T) {
 			BillingEntityRef: "be-0000",
 		},
 		Status: organizationv1.OrganizationStatus{
-			SaleOrderID: "123",
+			SalesOrderID: "123",
 		},
 	}
 	c := prepareTest(t, &subject)

--- a/controllers/saleorder/saleorder_storage.go
+++ b/controllers/saleorder/saleorder_storage.go
@@ -125,9 +125,9 @@ func (s *Odoo16SaleOrderStorage) GetSaleOrderName(org organizationv1.Organizatio
 		"id",
 		"name",
 	)
-	id, err := strconv.Atoi(org.Status.SaleOrderID)
+	id, err := strconv.Atoi(org.Status.SalesOrderID)
 	if err != nil {
-		return "", fmt.Errorf("error parsing saleOrderID %q from organization status: %w", org.Status.SaleOrderID, err)
+		return "", fmt.Errorf("error parsing saleOrderID %q from organization status: %w", org.Status.SalesOrderID, err)
 	}
 	soRecords := []odooclient.SaleOrder{}
 	err = s.client.Read(odooclient.SaleOrderModel, []int64{int64(id)}, fetchOrderFieldOpts, &soRecords)

--- a/controllers/saleorder/saleorder_storage_test.go
+++ b/controllers/saleorder/saleorder_storage_test.go
@@ -97,7 +97,7 @@ func TestGet(t *testing.T) {
 			BillingEntityRef: "be-123",
 		},
 		Status: organizationv1.OrganizationStatus{
-			SaleOrderID: "149",
+			SalesOrderID: "149",
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

...

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
