### PR TITLE
Allow organization BE ref validation to be skipped.

### DIFF
--- a/api.go
+++ b/api.go
@@ -31,10 +31,10 @@ import (
 func APICommand() *cobra.Command {
 	roles := []string{}
 	usernamePrefix := ""
-	var allowEmptyBillingEntity bool
+	var allowEmptyBillingEntity, skipBillingEntityValidation bool
 
 	ob := &odooStorageBuilder{}
-	ost := orgStore.New(&roles, &usernamePrefix, &allowEmptyBillingEntity)
+	ost := orgStore.New(&roles, &usernamePrefix, &allowEmptyBillingEntity, &skipBillingEntityValidation)
 	ib := &invitationStorageBuilder{usernamePrefix: &usernamePrefix}
 
 	cmd, err := builder.APIServer.
@@ -55,6 +55,7 @@ func APICommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&roles, "cluster-roles", []string{}, "Cluster Roles to bind when creating an organization")
 	cmd.Flags().StringVar(&usernamePrefix, "username-prefix", "", "Prefix prepended to username claims. Usually the same as \"--oidc-username-prefix\" of the Kubernetes API server")
 	cmd.Flags().BoolVar(&allowEmptyBillingEntity, "allow-empty-billing-entity", true, "Allow empty billing entity references")
+	cmd.Flags().BoolVar(&skipBillingEntityValidation, "organization-skip-billing-entity-validation", false, "Skip validation of billing entity references")
 
 	cmd.Flags().StringVar(&ob.billingEntityStorage, "billing-entity-storage", "fake", "Storage backend for billing entities. Supported values: fake, odoo8, odoo16")
 

--- a/apiserver/organization/organization.go
+++ b/apiserver/organization/organization.go
@@ -28,7 +28,7 @@ import (
 // +kubebuilder:rbac:groups="flowcontrol.apiserver.k8s.io",resources=prioritylevelconfigurations;flowschemas,verbs=get;list;watch
 
 // New returns a new storage provider for Organizations
-func New(clusterRoles *[]string, usernamePrefix *string, allowEmptyBillingEntity *bool) restbuilder.ResourceHandlerProvider {
+func New(clusterRoles *[]string, usernamePrefix *string, allowEmptyBillingEntity, skipBillingEntityValidation *bool) restbuilder.ResourceHandlerProvider {
 	return func(s *runtime.Scheme, g genericregistry.RESTOptionsGetter) (rest.Storage, error) {
 		masterConfig := loopback.GetLoopbackMasterClientConfig()
 
@@ -54,9 +54,10 @@ func New(clusterRoles *[]string, usernamePrefix *string, allowEmptyBillingEntity
 			members: kubeMemberProvider{
 				Client: c,
 			},
-			usernamePrefix:          *usernamePrefix,
-			impersonator:            impersonatorFromRestconf{masterConfig, client.Options{Scheme: c.Scheme()}},
-			allowEmptyBillingEntity: *allowEmptyBillingEntity,
+			usernamePrefix:              *usernamePrefix,
+			impersonator:                impersonatorFromRestconf{masterConfig, client.Options{Scheme: c.Scheme()}},
+			allowEmptyBillingEntity:     *allowEmptyBillingEntity,
+			skipBillingEntityValidation: *skipBillingEntityValidation,
 		}
 
 		return authwrapper.NewAuthorizedStorage(stor, metav1.GroupVersionResource{
@@ -78,7 +79,8 @@ type organizationStorage struct {
 
 	impersonator impersonator
 
-	allowEmptyBillingEntity bool
+	skipBillingEntityValidation bool
+	allowEmptyBillingEntity     bool
 }
 
 func (s organizationStorage) New() runtime.Object {


### PR DESCRIPTION
Required for migration when we switch off the BE part of the API-Server.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
