### PR TITLE
Remove categary id linking to old Odoo 8 "roleaccount"

### DIFF
--- a/apiserver/billing/odoostorage/odoo/odoo16/odoo16.go
+++ b/apiserver/billing/odoostorage/odoo/odoo16/odoo16.go
@@ -25,9 +25,6 @@ const VSHNAccountingContactNameKey = "billing.appuio.io/vshn-accounting-contact-
 // Used to identify the accounting contact of a company.
 const invoiceType = "invoice"
 
-// TODO(bastjan) test if still needed in odoo16
-const companyCategory = 2
-
 // Used to generate the UUID for the .metadata.uid field.
 var metaUIDNamespace = uuid.MustParse("7550b1ae-7a2a-485e-a75d-6f931b2cd73f")
 
@@ -442,15 +439,12 @@ func mapBillingEntityToPartners(be billingv1.BillingEntity, countryIDs map[strin
 }
 
 func setStaticAccountingContactFields(conf Config, a *odooclient.ResPartner) {
-	a.CategoryId = odooclient.NewRelation()
 	a.Lang = odooclient.NewSelection(conf.LanguagePreference)
 	a.Type = odooclient.NewSelection(invoiceType)
 	a.PropertyPaymentTermId = odooclient.NewMany2One(int64(conf.PaymentTermID), "")
 }
 
 func setStaticCompanyFields(conf Config, a *odooclient.ResPartner) {
-	a.CategoryId = odooclient.NewRelation()
-	a.CategoryId.AddRecord(int64(companyCategory))
 	a.Lang = odooclient.NewSelection(conf.LanguagePreference)
 	a.PropertyPaymentTermId = odooclient.NewMany2One(int64(conf.PaymentTermID), "")
 }


### PR DESCRIPTION
This should fix BE creation in Odoo 16.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
