### PR TITLE
Fix memory leak by reusing Odoo client

### DIFF
--- a/apiserver/billing/odoostorage/odoo/odoo16/odoo16mock/odoo16.go
+++ b/apiserver/billing/odoostorage/odoo/odoo16/odoo16mock/odoo16.go
@@ -82,6 +82,20 @@ func (mr *MockOdoo16ClientMockRecorder) FindResPartners(arg0, arg1 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindResPartners", reflect.TypeOf((*MockOdoo16Client)(nil).FindResPartners), arg0, arg1)
 }
 
+// FullInitialization mocks base method.
+func (m *MockOdoo16Client) FullInitialization() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FullInitialization")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FullInitialization indicates an expected call of FullInitialization.
+func (mr *MockOdoo16ClientMockRecorder) FullInitialization() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FullInitialization", reflect.TypeOf((*MockOdoo16Client)(nil).FullInitialization))
+}
+
 // Update mocks base method.
 func (m *MockOdoo16Client) Update(arg0 string, arg1 []int64, arg2 any) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The Odoo client uses http.Client under the hood which should be reused since it keeps connections open.

The initialization of the Odoo client is not thread-safe so I added a wrapper that fully initializes the client before any parallelized call. See comments on `FullInitialization()`.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
